### PR TITLE
스택트레이스를 파싱해서 일관된 포맷으로 표시

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/react": "^18.2.66",
     "@uiw/react-codemirror": "^4.21.24",
     "autoprefixer": "10.4.18",
+    "error-stack-parser-es": "^0.1.1",
     "jquery": "^3.7.1",
     "postcss": "8.4.36",
     "preact": "^10.19.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   autoprefixer:
     specifier: 10.4.18
     version: 10.4.18(postcss@8.4.36)
+  error-stack-parser-es:
+    specifier: ^0.1.1
+    version: 0.1.1
   jquery:
     specifier: ^3.7.1
     version: 3.7.1
@@ -1304,6 +1307,10 @@ packages:
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+    dev: false
+
+  /error-stack-parser-es@0.1.1:
+    resolution: {integrity: sha512-g/9rfnvnagiNf+DRMHEVGuGuIBlCIMDFoTA616HaP2l9PlCjGjVhD98PNbVSJvmK4TttqT5mV5tInMhoFgi+aA==}
     dev: false
 
   /esbuild@0.19.12:

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,6 +1,5 @@
 import { computed } from "@preact/signals";
 import * as React from "react";
-import CodeMirror from "@uiw/react-codemirror";
 import { EditorView } from "@codemirror/view";
 import { SdkVersion, sdkVersions } from "./sdk";
 import {
@@ -110,11 +109,9 @@ const Header: React.FC = () => {
                   />
                 )}
                 {(playResult.errorStack != null) && (
-                  <CodeMirror
-                    className="text-black"
-                    value={playResult.errorStack}
-                    readOnly
-                  />
+                  <div className="flex flex-col font-mono bg-white text-black whitespace-nowrap overflow-auto px-1">
+                    {playResult.errorStack}
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
크롬 기준으로는 썩 나쁘지 않게 표시되고 있었으나, 파이어폭스에서 표시되는 포맷에 정보가 과도하게 부족하여 이를 개선
|before|after|
|-|-|
|![image](https://github.com/portone-io/sdk-playground.portone.io/assets/8155259/4e83cbe6-a210-42be-9ba3-a95cda43b6a2)|![image](https://github.com/portone-io/sdk-playground.portone.io/assets/8155259/6415d9e5-f852-47d4-9f56-c9f039844695)|
