### PR TITLE
V1 체험하기의 pg 파라미터에 MID 명시

### DIFF
--- a/src/ui/trial.yaml
+++ b/src/ui/trial.yaml
@@ -4,12 +4,12 @@
     account:
       userCode: imp29272276
     field:
-      pg: inicis_unified
+      pg: inicis_unified.INIpayTest
   v1-pay:
     account:
       userCode: imp14397622
     field:
-      pg: html5_inicis
+      pg: html5_inicis.INIpayTest
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -39,7 +39,7 @@
       userCode: imp14397622
     uiType: paypal-spb
     field:
-      pg: paypal_v2
+      pg: paypal_v2.7WBB3CKT63FRG
       pay_method: paypal
       name: 테스트 결제
       amount: 1
@@ -58,7 +58,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: kcp
+      pg: kcp.T0000
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -80,7 +80,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: nice
+      pg: nice.nictest00m
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -118,7 +118,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: kicc
+      pg: kicc.T5102001
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -144,17 +144,17 @@
     case:
       💳 카드결제:
         pay_method: card
-        pg: danal_tpay
+        pg: danal_tpay.9810030929
       📱 휴대폰 소액결제:
         pay_method: phone
-        pg: danal
+        pg: danal.A010002002
 - label: 헥토파이낸셜
   icon: settle
   v1-pay:
     account:
       userCode: imp14397622
     field:
-      pg: settle
+      pg: settle.mid_test
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -174,7 +174,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: smartro
+      pg: smartro.iamport01m
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -216,7 +216,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: bluewalnut
+      pg: bluewalnut.imptest01m
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -236,7 +236,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: ksnet
+      pg: ksnet.2999199999
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -278,7 +278,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: tosspayments
+      pg: tosspayments.iamporttest_3
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -316,7 +316,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: uplus
+      pg: uplus.tlgdacomxpay
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -337,7 +337,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: daou
+      pg: daou.CTS17362
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -355,7 +355,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: mobilians
+      pg: mobilians.170622040674
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -368,7 +368,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: eximbay
+      pg: eximbay.1849705C64
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -381,7 +381,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: paymentwall
+      pg: paymentwall.790d26a46214d76957edaf9aaa7bb6db
       name: 테스트 결제
       amount: 1000
       buyer_tel: 010-0000-0000
@@ -395,7 +395,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: kakaopay
+      pg: kakaopay.TC0ONETIME
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -420,7 +420,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: tosspay
+      pg: tosspay.tosstest
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -445,7 +445,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: payco
+      pg: payco.PARTNERTEST
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000
@@ -458,7 +458,7 @@
     account:
       userCode: imp14397622
     field:
-      pg: smilepay
+      pg: smilepay.cnstest25m
       name: 테스트 결제
       amount: 100
       buyer_tel: 010-0000-0000


### PR DESCRIPTION
pg 파라미터의 권장되는 사용법에 따라, PG Provider 정보뿐만이 아닌 MID를 함께 명시합니다.

ref: https://developers.portone.io/docs/ko/sdk/javascript-sdk/payrq?v=v1#pg-string