### PR TITLE
Union 타입 필드 출력 오류 수정

### DIFF
--- a/src/state/fields.ts
+++ b/src/state/fields.ts
@@ -375,7 +375,7 @@ export function createConfigObjectSignal({
 		input: Input,
 		fieldSignal: FieldSignal,
 	): unknown {
-		return matchFieldSignalType({
+		return matchFieldSignalType<unknown>({
 			input,
 			fieldSignal,
 			object: (input, fieldSignal) =>
@@ -384,11 +384,13 @@ export function createConfigObjectSignal({
 				const key = fieldSignal.activeKeySignal.value;
 				const selectedField = input.fields[key];
 				const selectedFieldSignal = fieldSignal.valueSignal.value[key];
-				return getFieldObject(
-					selectedField,
-					selectedField.input,
-					selectedFieldSignal,
-				);
+				return {
+					[key]: getFieldObject(
+						selectedField,
+						selectedField.input,
+						selectedFieldSignal,
+					),
+				};
 			},
 			array: (input, fieldSignal) =>
 				fieldSignal.valueSignal.value.map((itemSignal: FieldSignal) =>


### PR DESCRIPTION
Union 타입 필드를 config object로 출력할 때, `unionField: { unionEntry: value }` 형태가 되어야 할 것이 `unionField: value` 로 출력되던 문제를 수정합니다.