### PR TITLE
pnpm@8.15.8 버전 명시

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,6 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.6.4"
-	}
+	},
+	"packageManager": "pnpm@8.15.8"
 }


### PR DESCRIPTION
package.json에 packageManager 옵션이 없어서 corepack 사용 시 pnpm 9버전으로 실행되는 바람에 pnpm@8 기준으로 작성된 lock파일이 깨집니다.