### PR TITLE
vite dev 환경에서 발생하는 import 오류 수정

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -19,6 +19,6 @@
 		"indentStyle": "tab"
 	},
 	"files": {
-		"ignore": ["node_modules", "dist", ".vscode"]
+		"ignore": ["node_modules", "dist", ".vscode", "public/sdk"]
 	}
 }

--- a/src/misc/import-static.ts
+++ b/src/misc/import-static.ts
@@ -1,0 +1,8 @@
+// https://github.com/vitejs/vite/issues/14850#issuecomment-1907266103
+export function importStatic(modulePath: string) {
+	if (import.meta.env.DEV) {
+		return import(/* @vite-ignore */ `${modulePath}?${Date.now()}`);
+	} else {
+		return import(/* @vite-ignore */ modulePath);
+	}
+}

--- a/src/misc/import-static.ts
+++ b/src/misc/import-static.ts
@@ -2,7 +2,6 @@
 export function importStatic(modulePath: string) {
 	if (import.meta.env.DEV) {
 		return import(/* @vite-ignore */ `${modulePath}?${Date.now()}`);
-	} else {
-		return import(/* @vite-ignore */ modulePath);
 	}
+	return import(/* @vite-ignore */ modulePath);
 }

--- a/src/state/v1.ts
+++ b/src/state/v1.ts
@@ -10,6 +10,7 @@ import type { SdkV1, SdkV1Version } from "../sdk";
 import { getMajorVersion, sdkVersionSignal } from "./app";
 import persisted, { prefix } from "./persisted";
 import { createUrlSignal } from "./url";
+import { importStatic } from "../misc/import-static";
 
 declare global {
 	interface Window {
@@ -76,7 +77,7 @@ async function loadSdkV1(
 	return match(version)
 		.with("1.3.0", async () => {
 			const { default: IMP, slots } = import.meta.env.VITE_BROWSER_SDK_V1
-				? await import(/* @vite-ignore */ import.meta.env.VITE_BROWSER_SDK_V1)
+				? await importStatic(import.meta.env.VITE_BROWSER_SDK_V1)
 				: await import("https://cdn.iamport.kr/v1/iamport.esm.js");
 			const cleanUp = IMP.deinit;
 			slots.CORE_SERVER = CORE_SERVER;

--- a/src/state/v1.ts
+++ b/src/state/v1.ts
@@ -6,11 +6,11 @@ import {
 	signal,
 } from "@preact/signals";
 import { P, match } from "ts-pattern";
+import { importStatic } from "../misc/import-static";
 import type { SdkV1, SdkV1Version } from "../sdk";
 import { getMajorVersion, sdkVersionSignal } from "./app";
 import persisted, { prefix } from "./persisted";
 import { createUrlSignal } from "./url";
-import { importStatic } from "../misc/import-static";
 
 declare global {
 	interface Window {

--- a/src/state/v2.ts
+++ b/src/state/v2.ts
@@ -5,6 +5,7 @@ import persisted, { prefix } from "./persisted";
 import { createUrlSignal } from "./url";
 
 import { Entity } from "https://esm.sh/@portone/browser-sdk/v2?exports=Entity";
+import { importStatic } from "../misc/import-static";
 
 export function reset() {
 	checkoutServerSignal.value = defaultCheckoutServer;
@@ -53,7 +54,7 @@ async function loadSdkV2(
 	switch (version) {
 		case "2.0.0": {
 			const { default: PortOne, slots } = import.meta.env.VITE_BROWSER_SDK_V2
-				? await import(/* @vite-ignore */ import.meta.env.VITE_BROWSER_SDK_V2)
+				? await importStatic(import.meta.env.VITE_BROWSER_SDK_V2)
 				: await import("https://cdn.portone.io/v2/browser-sdk.esm.js");
 			Object.assign(slots, { CHECKOUT_SERVER });
 			return { PortOne, cleanUp: () => {} };


### PR DESCRIPTION
로컬 개발 환경 개선을 위해, 기존 vite 빌드 후 `dist`에 sdk 복사하는 흐름에서, `public`에 sdk 복사 하고 vite 빌드로 변경하는 작업을 진행하고 있습니다. (이렇게 해야 vite dev 서버에서 개발이 가능하기 때문)
이렇게 했을 때 dev 환경에서 public에 위치한 sdk import를 시도하면 이런 오류가 발생하는데요

```bash
Failed to load url /sdk/v2/browser-sdk.esm.js (resolved id: /sdk/v2/browser-sdk.esm.js). This file is in /public and will be copied as-is during build without going through the plugin transforms, and therefore should not be imported from source code. It can only be referenced via HTML tags.
```

이 오류를 해결하기 위해 [vite issue에서 임시방편으로 제시한 함수](https://github.com/vitejs/vite/issues/14850#issuecomment-1907266103)를 사용하도록 하는 PR입니다.