### PR TITLE
V2 빌링 키 발급 누락된 필드 추가

### DIFF
--- a/src/state/v2-issue-billing-key.ts
+++ b/src/state/v2-issue-billing-key.ts
@@ -43,6 +43,24 @@ export const codePreviewSignal = computed<string>(() => {
 export const fields = {
 	storeId: v2PayFields.storeId,
 	channelKey: v2PayFields.channelKey,
+	issueName: {
+		required: false,
+		label: "빌링 키 발급 주문 명",
+		input: {
+			type: "text",
+			default: "",
+			placeholder: "빌링 키 발급 주문 명",
+		},
+	},
+	issueId: {
+		required: false,
+		label: "빌링 키 발급 주문 고유번호",
+		input: {
+			type: "text",
+			default: "",
+			placeholder: "빌링 키 발급 주문 고유번호",
+		},
+	},
 	billingKeyMethod: {
 		required: true,
 		label: "빌링 키 발급 수단",


### PR DESCRIPTION
이니시스로 빌링 키를 발급할 때, `issueName` 과 `issueId`가 필수 파라미터이나 필드에 정의되어 있지 않았음