### PR TITLE
V2 PG 정기결제 UI 페이지 추가 및 버그 수정

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -21,6 +21,7 @@ import { accountSignals as v1PayAccountSignals } from "./state/v1-pay";
 import { fieldSignals as v2IdentityVerificationFieldSignals } from "./state/v2-identity-verification";
 import { fieldSignals as v2IssueBillingKeyFieldSignals } from "./state/v2-issue-billing-key";
 import { fieldSignals as v2IssueBillingKeyAndPayFieldSignals } from "./state/v2-issue-billing-key-and-pay";
+import { fieldSignals as v2LoadBillingKeyUiFieldSignals } from "./state/v2-load-billing-key-ui";
 import { fieldSignals as v2LoadPaymentUiFieldSignals } from "./state/v2-load-payment-ui";
 import { fieldSignals as v2PayFieldSignals } from "./state/v2-pay";
 import JsonEditor from "./ui/JsonEditor";
@@ -34,6 +35,8 @@ export const showTrialSignal = computed(() => {
 	const v2PayStoreId = v2PayFieldSignals.storeId.valueSignal.value;
 	const v2LoadPaymentUiStoreId =
 		v2LoadPaymentUiFieldSignals.storeId.valueSignal.value;
+	const v2LoadBillingKeyUiStoreId =
+		v2LoadBillingKeyUiFieldSignals.storeId.valueSignal.value;
 	const v2IdentityVerificationStoreId =
 		v2IdentityVerificationFieldSignals.storeId.valueSignal.value;
 	const v2IssueBillingKeyStoreId =
@@ -47,6 +50,7 @@ export const showTrialSignal = computed(() => {
 		.with("v1-load-ui", () => !v1LoadUiUserCode)
 		.with("v2-pay", () => !v2PayStoreId)
 		.with("v2-load-payment-ui", () => !v2LoadPaymentUiStoreId)
+		.with("v2-load-billing-key-ui", () => !v2LoadBillingKeyUiStoreId)
 		.with("v2-identity-verification", () => !v2IdentityVerificationStoreId)
 		.with("v2-issue-billing-key", () => !v2IssueBillingKeyStoreId)
 		.with("v2-issue-billing-key-and-pay", () => !v2IssueBillingKeyAndPayStoreId)

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,6 +1,7 @@
 import { EditorView } from "@codemirror/view";
 import { computed } from "@preact/signals";
 import type * as React from "react";
+import { match } from "ts-pattern";
 import { type SdkVersion, isSupportedVersion, sdkVersions } from "./sdk";
 import {
 	appModeSignal,
@@ -18,6 +19,8 @@ import { accountSignals as v1CertAccountSignals } from "./state/v1-cert";
 import { accountSignals as v1LoadUiAccountSignals } from "./state/v1-load-ui";
 import { accountSignals as v1PayAccountSignals } from "./state/v1-pay";
 import { fieldSignals as v2IdentityVerificationFieldSignals } from "./state/v2-identity-verification";
+import { fieldSignals as v2IssueBillingKeyFieldSignals } from "./state/v2-issue-billing-key";
+import { fieldSignals as v2IssueBillingKeyAndPayFieldSignals } from "./state/v2-issue-billing-key-and-pay";
 import { fieldSignals as v2LoadPaymentUiFieldSignals } from "./state/v2-load-payment-ui";
 import { fieldSignals as v2PayFieldSignals } from "./state/v2-pay";
 import JsonEditor from "./ui/JsonEditor";
@@ -33,20 +36,21 @@ export const showTrialSignal = computed(() => {
 		v2LoadPaymentUiFieldSignals.storeId.valueSignal.value;
 	const v2IdentityVerificationStoreId =
 		v2IdentityVerificationFieldSignals.storeId.valueSignal.value;
-	switch (modeFn) {
-		case "v1-pay":
-			return !v1PayUserCode;
-		case "v1-cert":
-			return !v1CertUserCode;
-		case "v1-load-ui":
-			return !v1LoadUiUserCode;
-		case "v2-pay":
-			return !v2PayStoreId;
-		case "v2-load-payment-ui":
-			return !v2LoadPaymentUiStoreId;
-		case "v2-identity-verification":
-			return !v2IdentityVerificationStoreId;
-	}
+	const v2IssueBillingKeyStoreId =
+		v2IssueBillingKeyFieldSignals.storeId.valueSignal.value;
+	const v2IssueBillingKeyAndPayStoreId =
+		v2IssueBillingKeyAndPayFieldSignals.storeId.valueSignal.value;
+
+	return match(modeFn)
+		.with("v1-pay", () => !v1PayUserCode)
+		.with("v1-cert", () => !v1CertUserCode)
+		.with("v1-load-ui", () => !v1LoadUiUserCode)
+		.with("v2-pay", () => !v2PayStoreId)
+		.with("v2-load-payment-ui", () => !v2LoadPaymentUiStoreId)
+		.with("v2-identity-verification", () => !v2IdentityVerificationStoreId)
+		.with("v2-issue-billing-key", () => !v2IssueBillingKeyStoreId)
+		.with("v2-issue-billing-key-and-pay", () => !v2IssueBillingKeyAndPayStoreId)
+		.exhaustive();
 });
 
 const Header: React.FC = () => {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -87,6 +87,10 @@ export interface SdkV2 {
 			config: unknown,
 			callbacks: Record<string, (value: unknown) => void>,
 		): Promise<unknown>;
+		loadIssueBillingKeyUI(
+			request: unknown,
+			callbacks: Record<string, (value: unknown) => void>,
+		): Promise<void>;
 	};
 	cleanUp: () => void;
 }

--- a/src/state/app.tsx
+++ b/src/state/app.tsx
@@ -49,6 +49,10 @@ export const modeFns = {
 		label: "PG 결제 UI",
 		stateModule: () => import("./v2-load-payment-ui"),
 	},
+	"v2-load-billing-key-ui": {
+		label: "PG 정기결제 UI",
+		stateModule: () => import("./v2-load-billing-key-ui"),
+	},
 	"v2-issue-billing-key": {
 		label: "빌링 키 발급",
 		stateModule: () => import("./v2-issue-billing-key"),
@@ -68,6 +72,7 @@ export const modeFnKeysPerVersion: { [key in SdkVersion]: ModeFnKey[] } = {
 		"v2-pay",
 		"v2-identity-verification",
 		"v2-load-payment-ui",
+		"v2-load-billing-key-ui",
 		"v2-issue-billing-key",
 		"v2-issue-billing-key-and-pay",
 	],

--- a/src/state/app.tsx
+++ b/src/state/app.tsx
@@ -145,14 +145,7 @@ export const playFnSignal = computed(() => {
 					P.union({ error_code: P.nonNullable }, { code: P.nonNullable }),
 					() => false,
 				)
-				.with(
-					P.intersection(
-						{ code: P.optional(P.nonNullable) },
-						{ error_code: P.optional(P.nonNullable) },
-					),
-					() => true,
-				)
-				.exhaustive();
+				.otherwise(() => true);
 			playResultSignal.value = { success, response };
 		} catch (error) {
 			console.error(error);

--- a/src/state/v2-issue-billing-key.ts
+++ b/src/state/v2-issue-billing-key.ts
@@ -61,6 +61,18 @@ export const fields = {
 			placeholder: "빌링 키 발급 주문 고유번호",
 		},
 	},
+	displayAmount: {
+		required: false,
+		label: "표시용 결제 금액",
+		input: {
+			type: "integer",
+			default: 1000,
+		},
+	},
+	currency: {
+		...v2PayFields.currency,
+		required: false,
+	},
 	billingKeyMethod: {
 		required: true,
 		label: "빌링 키 발급 수단",

--- a/src/state/v2-load-billing-key-ui.ts
+++ b/src/state/v2-load-billing-key-ui.ts
@@ -1,0 +1,93 @@
+import { computed } from "@preact/signals";
+import { toJs } from "./code";
+import {
+	type Fields,
+	createConfigObjectSignal,
+	createFieldSignals,
+	createJsonSignals,
+	resetFieldSignals,
+} from "./fields";
+import persisted, { prefix } from "./persisted";
+import { pgUiModalOpenSignal } from "./v1-load-ui";
+import { IssueBillingKeyUITypeOptions, sdkV2Signal } from "./v2";
+import { fields as v2IssueBillingKeyFields } from "./v2-issue-billing-key";
+
+export function reset() {
+	resetFieldSignals(fields, fieldSignals);
+	jsonTextSignal.value = "{}";
+}
+
+export const playFnSignal = computed(() => {
+	const sdkV2 = sdkV2Signal.value;
+	const configObject = configObjectSignal.value;
+	return function loadIssueBillingKeyUI() {
+		if (!sdkV2) return Promise.reject(new Error("sdk not loaded"));
+		return new Promise((resolve, reject) => {
+			sdkV2.PortOne.loadIssueBillingKeyUI(configObject, {
+				onIssueBillingKeySuccess: resolve,
+				onIssueBillingKeyFail: resolve,
+			}).catch(reject);
+			pgUiModalOpenSignal.value = true;
+		}).finally(() => {
+			pgUiModalOpenSignal.value = false;
+		});
+	};
+});
+
+export const codePreviewSignal = computed<string>(() => {
+	const configObject = configObjectSignal.value;
+	const uiType = fieldSignals.uiType.valueSignal.value;
+	const uiTypeRepr = JSON.stringify(uiType);
+	return [
+		`<script src="https://cdn.portone.io/v2/browser-sdk.js"></script>`,
+		"",
+		`<div class="portone-ui-container" data-portone-ui-type=${uiTypeRepr}>`,
+		"  <!-- 여기에 PG사 전용 버튼이 그려집니다 -->",
+		"</div>",
+		"",
+		"<script>",
+		`PortOne.loadIssueBillingKeyUI(${toJs(configObject)});`,
+		"</script>",
+	].join("\n");
+});
+
+export const fields = {
+	uiType: {
+		required: true,
+		label: "PG 정기결제 UI 형식",
+		input: {
+			type: "enum",
+			placeholder: "PAYPAL_RT",
+			default: "PAYPAL_RT",
+			options: IssueBillingKeyUITypeOptions,
+		},
+	},
+	storeId: v2IssueBillingKeyFields.storeId,
+	channelKey: v2IssueBillingKeyFields.channelKey,
+	billingKeyMethod: {
+		required: true,
+		label: v2IssueBillingKeyFields.billingKeyMethod.label,
+		input: {
+			type: "enum",
+			options: ["PAYPAL"],
+			default: "PAYPAL",
+			placeholder: "PAYPAL",
+		},
+	},
+	issueName: v2IssueBillingKeyFields.issueName,
+	issueId: v2IssueBillingKeyFields.issueId,
+	customer: v2IssueBillingKeyFields.customer,
+} as const satisfies Fields;
+
+export const fieldSignals = createFieldSignals(
+	localStorage,
+	`${prefix}.v2-load-billing-key-ui.fields`,
+	fields,
+);
+export const { jsonTextSignal, jsonValueSignal, isEmptyJsonSignal } =
+	createJsonSignals(localStorage, `${prefix}.v2-load-billing-key-ui.json`);
+export const configObjectSignal = createConfigObjectSignal({
+	fields,
+	fieldSignals,
+	jsonValueSignal,
+});

--- a/src/state/v2.ts
+++ b/src/state/v2.ts
@@ -69,6 +69,9 @@ export const giftCertificateTypeOptions = Object.keys(
 	Entity.GiftCertificateType,
 );
 export const paymentUITypeOptions = Object.keys(Entity.PaymentUIType);
+export const IssueBillingKeyUITypeOptions = Object.keys(
+	Entity.IssueBillingKeyUIType,
+);
 export const easyPayProviderOptions = Object.keys(Entity.EasyPayProvider);
 export const currencyOptions = Object.keys(Entity.Currency);
 export const countryOptions = Object.keys(Entity.Country);

--- a/src/ui/mode/Mode.tsx
+++ b/src/ui/mode/Mode.tsx
@@ -6,6 +6,7 @@ import V1Pay from "./v1-pay";
 import V2IdentityVerification from "./v2-identity-verification";
 import V2IssueBillingKey from "./v2-issue-billing-key";
 import V2IssueBillingKeyAndPay from "./v2-issue-billing-key-and-pay";
+import V2LoadBillingKeyUi from "./v2-load-billing-key-ui";
 import V2LoadPaymentUi from "./v2-load-payment-ui";
 import V2Pay from "./v2-pay";
 
@@ -16,6 +17,7 @@ const modeViewTable: { [key in ModeFnKey]: React.ReactElement } = {
 	"v2-pay": <V2Pay />,
 	"v2-identity-verification": <V2IdentityVerification />,
 	"v2-load-payment-ui": <V2LoadPaymentUi />,
+	"v2-load-billing-key-ui": <V2LoadBillingKeyUi />,
 	"v2-issue-billing-key": <V2IssueBillingKey />,
 	"v2-issue-billing-key-and-pay": <V2IssueBillingKeyAndPay />,
 };

--- a/src/ui/mode/v2-load-billing-key-ui.tsx
+++ b/src/ui/mode/v2-load-billing-key-ui.tsx
@@ -1,0 +1,100 @@
+import { signal, useSignal } from "@preact/signals";
+import type * as React from "react";
+import { checkoutServerSignal, reset as resetV2 } from "../../state/v2";
+import {
+	codePreviewSignal,
+	fieldSignals,
+	fields,
+	isEmptyJsonSignal,
+	jsonTextSignal,
+	jsonValueSignal,
+	reset,
+} from "../../state/v2-load-billing-key-ui";
+import { RequiredIndicator } from "../Control";
+import HtmlEditor from "../HtmlEditor";
+import JsonEditor from "../JsonEditor";
+import FieldControls from "../field/FieldControls";
+import Reset from "./Reset";
+
+const resetCountSignal = signal(0);
+const resetFn = () => {
+	resetV2();
+	reset();
+	++resetCountSignal.value;
+};
+
+const View: React.FC = () => {
+	const parseJsonFailed = jsonValueSignal.value == null;
+	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+	return (
+		<>
+			<p className="mb-4 text-xs text-slate-500">
+				PG가 콘솔에서 테스트로 설정된 경우, 승인된 결제 건은 매일
+				자정(23:00~23:50분 사이)에 자동으로 취소됩니다.
+				<br />
+				"<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
+				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
+			</p>
+			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+				<div className="flex flex-col gap-2 md:pb-80">
+					<Reset resetFn={resetFn} />
+					<details open={isJsonOpen.value}>
+						<summary
+							className={`text-xs ${
+								parseJsonFailed ? "text-red-700" : "text-slate-500"
+							} cursor-pointer`}
+						>
+							추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
+						</summary>
+						<JsonEditor
+							key={resetCountSignal.value}
+							value={jsonTextSignal.value}
+							onChange={(json) => {
+								jsonTextSignal.value = json;
+							}}
+							onReset={() => {
+								isJsonOpen.value = true;
+							}}
+						/>
+						<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
+							<summary className="text-xs text-slate-500 cursor-pointer">
+								포트원 내부 QA 전용 설정
+							</summary>
+							<div className="flex flex-col gap-2">
+								<label>
+									<div>Checkout API URL</div>
+									<input
+										type="text"
+										className="border w-full"
+										value={checkoutServerSignal.value}
+										onChange={(e) => {
+											checkoutServerSignal.value = e.currentTarget.value;
+										}}
+									/>
+								</label>
+							</div>
+						</details>
+					</details>
+					<FieldControls fields={fields} fieldSignals={fieldSignals} />
+				</div>
+				<div>
+					<div
+						className="md:sticky top-4 flex flex-col"
+						style={{ height: "calc(100vh - 2rem)" }}
+					>
+						<h2 className="text-xs text-slate-500">연동 코드 예시</h2>
+						<div className="flex-1">
+							<HtmlEditor
+								className="h-full"
+								readOnly
+								value={codePreviewSignal.value}
+							/>
+						</div>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default View;


### PR DESCRIPTION
[Slack 논의](https://portone-io.slack.com/archives/C02KQFUB8GG/p1719908069506669?thread_ts=1719813728.836489&cid=C02KQFUB8GG), [Slack 논의2](https://portone-io.slack.com/archives/C02KQFUB8GG/p1720147438899359?thread_ts=1720092855.025359&cid=C02KQFUB8GG)

- V2 PG 정기결제 UI 페이지 추가
- V2 빌링 키 발급, 빌링 키 발급 및 결제 페이지로 이동하면 실행 버튼이 체험하기 버튼으로 변경되는 문제 수정
- V2 빌링 키 발급 페이지에 누락된 `displayAmount`, `currency` 필드 추가
- 실행 결과에 `code`나 `error_code`가 undefined일 경우에도 실행 실패로 표시되는 문제 수정

![image](https://github.com/portone-io/sdk-playground.portone.io/assets/17797795/617a8985-c27a-48a6-9082-fa5c97d55204)
