### PR TITLE
SDK 상태를 Promise로 관리하도록 개선

### DIFF
--- a/src/state/v1-cert.ts
+++ b/src/state/v1-cert.ts
@@ -23,13 +23,12 @@ export const playFnSignal = computed(() => {
 	const sdkV1 = sdkV1Signal.value;
 	const userCode = accountSignals.userCodeSignal.value;
 	const configObject = configObjectSignal.value;
-	return function certification() {
-		if (!sdkV1) return Promise.reject(new Error("sdk not loaded"));
-		return new Promise((resolve, reject) => {
-			if (!userCode) reject(new Error("userCode is empty"));
-			accountSignals.impInit(sdkV1);
-			sdkV1.IMP.certification(configObject, resolve);
-		});
+	return async function certification() {
+		if (!sdkV1) throw new Error("sdk not loaded");
+		if (!userCode) throw new Error("userCode is empty");
+		const { IMP } = await sdkV1;
+		accountSignals.impInit(IMP);
+		return new Promise((resolve) => IMP.certification(configObject, resolve));
 	};
 });
 

--- a/src/state/v1-load-ui.ts
+++ b/src/state/v1-load-ui.ts
@@ -32,12 +32,13 @@ export const playFnSignal = computed(() => {
 	const userCode = accountSignals.userCodeSignal.value;
 	const uiType = uiTypeSignal.value;
 	const configObject = configObjectSignal.value;
-	return function loadUI() {
-		if (!sdkV1) return Promise.reject(new Error("sdk not loaded"));
-		return new Promise((resolve, reject) => {
-			if (!userCode) reject(new Error("userCode is empty"));
-			accountSignals.impInit(sdkV1);
-			sdkV1.IMP.loadUI(uiType, configObject, (response) => {
+	return async function loadUI() {
+		if (!sdkV1) throw new Error("sdk not loaded");
+		if (!userCode) throw new Error("userCode is empty");
+		const { IMP } = await sdkV1;
+		accountSignals.impInit(IMP);
+		return new Promise((resolve) => {
+			IMP.loadUI(uiType, configObject, (response) => {
 				resolve(response);
 				pgUiModalOpenSignal.value = false;
 			});

--- a/src/state/v1-pay.ts
+++ b/src/state/v1-pay.ts
@@ -23,12 +23,13 @@ export const playFnSignal = computed(() => {
 	const sdkV1 = sdkV1Signal.value;
 	const userCode = accountSignals.userCodeSignal.value;
 	const configObject = configObjectSignal.value;
-	return function requestPay() {
-		if (!sdkV1) return Promise.reject(new Error("sdk not loaded"));
-		return new Promise((resolve, reject) => {
-			if (!userCode) reject(new Error("userCode is empty"));
-			accountSignals.impInit(sdkV1);
-			sdkV1.IMP.request_pay(configObject, resolve);
+	return async function requestPay() {
+		if (!sdkV1) throw new Error("sdk not loaded");
+		if (!userCode) throw new Error("userCode is empty");
+		const { IMP } = await sdkV1;
+		accountSignals.impInit(IMP);
+		return new Promise((resolve) => {
+			IMP.request_pay(configObject, resolve);
 		});
 	};
 });

--- a/src/state/v1.ts
+++ b/src/state/v1.ts
@@ -50,7 +50,7 @@ effect(() => {
 		return;
 	}
 	let cleaned = false;
-	(async (version) => {
+	(async () => {
 		if (getMajorVersion(version) === "v1") {
 			const sdk = loadSdkV1(
 				version as SdkV1Version,
@@ -62,7 +62,7 @@ effect(() => {
 		} else {
 			sdkV1Signal.value = undefined;
 		}
-	})(version);
+	})();
 	return () => {
 		cleaned = true;
 		sdkV1Signal.value?.then((sdk) => sdk.cleanUp());

--- a/src/state/v1.ts
+++ b/src/state/v1.ts
@@ -39,7 +39,7 @@ export const checkoutServerSignal = persisted(
 );
 export const checkoutServerUrlSignal = createUrlSignal(checkoutServerSignal);
 
-export const sdkV1Signal = signal<SdkV1 | undefined>(undefined);
+export const sdkV1Signal = signal<Promise<SdkV1> | undefined>(undefined);
 
 effect(() => {
 	const version = sdkVersionSignal.value;
@@ -50,9 +50,9 @@ effect(() => {
 		return;
 	}
 	let cleaned = false;
-	(async () => {
+	(async (version) => {
 		if (getMajorVersion(version) === "v1") {
-			const sdk = await loadSdkV1(
+			const sdk = loadSdkV1(
 				version as SdkV1Version,
 				coreServerUrl.origin,
 				checkoutServerUrl.origin,
@@ -62,10 +62,10 @@ effect(() => {
 		} else {
 			sdkV1Signal.value = undefined;
 		}
-	})();
+	})(version);
 	return () => {
 		cleaned = true;
-		sdkV1Signal.value?.cleanUp();
+		sdkV1Signal.value?.then((sdk) => sdk.cleanUp());
 	};
 });
 
@@ -141,7 +141,7 @@ export interface AccountSignals {
 	tierCodeEnabledSignal: Signal<boolean>;
 	codePreviewSignal: ReadonlySignal<string>;
 	reset: () => void;
-	impInit: (sdkV1: SdkV1) => void;
+	impInit: (IMP: SdkV1["IMP"]) => void;
 }
 export function createAccountSignals(keyPrefix: string): AccountSignals {
 	const userCodeSignal = persisted(localStorage, `${keyPrefix}.userCode`, "");
@@ -172,12 +172,12 @@ export function createAccountSignals(keyPrefix: string): AccountSignals {
 			tierCodeSignal.value = "";
 			tierCodeEnabledSignal.value = false;
 		},
-		impInit(sdkV1) {
+		impInit(IMP) {
 			const userCode = userCodeSignal.value;
 			const tierCode = tierCodeSignal.value;
 			const tierCodeEnabled = tierCodeEnabledSignal.value;
-			if (tierCodeEnabled && tierCode) sdkV1.IMP.agency(userCode, tierCode);
-			else sdkV1.IMP.init(userCode);
+			if (tierCodeEnabled && tierCode) IMP.agency(userCode, tierCode);
+			else IMP.init(userCode);
 		},
 	};
 }

--- a/src/state/v2-identity-verification.ts
+++ b/src/state/v2-identity-verification.ts
@@ -23,9 +23,10 @@ export function reset() {
 export const playFnSignal = computed(() => {
 	const sdkV2 = sdkV2Signal.value;
 	const configObject = configObjectSignal.value;
-	return function requestIdentityVerification() {
-		if (!sdkV2) return Promise.reject(new Error("sdk not loaded"));
-		return sdkV2.PortOne.requestIdentityVerification(configObject);
+	return async function requestIdentityVerification() {
+		if (!sdkV2) throw new Error("sdk not loaded");
+		const { PortOne } = await sdkV2;
+		return PortOne.requestIdentityVerification(configObject);
 	};
 });
 

--- a/src/state/v2-issue-billing-key-and-pay.ts
+++ b/src/state/v2-issue-billing-key-and-pay.ts
@@ -19,9 +19,10 @@ export function reset() {
 export const playFnSignal = computed(() => {
 	const sdkV2 = sdkV2Signal.value;
 	const configObject = configObjectSignal.value;
-	return function requestIssueBillingKeyAndPay() {
-		if (!sdkV2) return Promise.reject(new Error("sdk not loaded"));
-		return sdkV2.PortOne.requestIssueBillingKeyAndPay(configObject);
+	return async function requestIssueBillingKeyAndPay() {
+		if (!sdkV2) throw new Error("sdk not loaded");
+		const { PortOne } = await sdkV2;
+		return PortOne.requestIssueBillingKeyAndPay(configObject);
 	};
 });
 

--- a/src/state/v2-issue-billing-key.ts
+++ b/src/state/v2-issue-billing-key.ts
@@ -19,9 +19,10 @@ export function reset() {
 export const playFnSignal = computed(() => {
 	const sdkV2 = sdkV2Signal.value;
 	const configObject = configObjectSignal.value;
-	return function requestIssueBillingKey() {
-		if (!sdkV2) return Promise.reject(new Error("sdk not loaded"));
-		return sdkV2.PortOne.requestIssueBillingKey(configObject);
+	return async function requestIssueBillingKey() {
+		if (!sdkV2) throw new Error("sdk not loaded");
+		const { PortOne } = await sdkV2;
+		return PortOne.requestIssueBillingKey(configObject);
 	};
 });
 

--- a/src/state/v2-load-billing-key-ui.ts
+++ b/src/state/v2-load-billing-key-ui.ts
@@ -20,17 +20,20 @@ export function reset() {
 export const playFnSignal = computed(() => {
 	const sdkV2 = sdkV2Signal.value;
 	const configObject = configObjectSignal.value;
-	return function loadIssueBillingKeyUI() {
-		if (!sdkV2) return Promise.reject(new Error("sdk not loaded"));
-		return new Promise((resolve, reject) => {
-			sdkV2.PortOne.loadIssueBillingKeyUI(configObject, {
-				onIssueBillingKeySuccess: resolve,
-				onIssueBillingKeyFail: resolve,
-			}).catch(reject);
-			pgUiModalOpenSignal.value = true;
-		}).finally(() => {
+	return async function loadIssueBillingKeyUI() {
+		if (!sdkV2) throw new Error("sdk not loaded");
+		const { PortOne } = await sdkV2;
+		try {
+			return await new Promise((resolve, reject) => {
+				PortOne.loadIssueBillingKeyUI(configObject, {
+					onIssueBillingKeySuccess: resolve,
+					onIssueBillingKeyFail: resolve,
+				}).catch(reject);
+				pgUiModalOpenSignal.value = true;
+			});
+		} finally {
 			pgUiModalOpenSignal.value = false;
-		});
+		}
 	};
 });
 

--- a/src/state/v2-load-payment-ui.ts
+++ b/src/state/v2-load-payment-ui.ts
@@ -20,17 +20,20 @@ export function reset() {
 export const playFnSignal = computed(() => {
 	const sdkV2 = sdkV2Signal.value;
 	const configObject = configObjectSignal.value;
-	return function loadPaymentUI() {
-		if (!sdkV2) return Promise.reject(new Error("sdk not loaded"));
-		return new Promise((resolve, reject) => {
-			sdkV2.PortOne.loadPaymentUI(configObject, {
-				onPaymentSuccess: resolve,
-				onPaymentFail: resolve,
-			}).catch(reject);
-			pgUiModalOpenSignal.value = true;
-		}).finally(() => {
+	return async function loadPaymentUI() {
+		if (!sdkV2) throw new Error("sdk not loaded");
+		const { PortOne } = await sdkV2;
+		try {
+			return await new Promise((resolve, reject) => {
+				PortOne.loadPaymentUI(configObject, {
+					onPaymentSuccess: resolve,
+					onPaymentFail: resolve,
+				}).catch(reject);
+				pgUiModalOpenSignal.value = true;
+			});
+		} finally {
 			pgUiModalOpenSignal.value = false;
-		});
+		}
 	};
 });
 

--- a/src/state/v2-pay.ts
+++ b/src/state/v2-pay.ts
@@ -32,9 +32,10 @@ export function reset() {
 export const playFnSignal = computed(() => {
 	const sdkV2 = sdkV2Signal.value;
 	const configObject = configObjectSignal.value;
-	return function requestPay() {
-		if (!sdkV2) return Promise.reject(new Error("sdk not loaded"));
-		return sdkV2.PortOne.requestPayment(configObject);
+	return async function requestPay() {
+		if (!sdkV2) throw new Error("sdk not loaded");
+		const { PortOne } = await sdkV2;
+		return PortOne.requestPayment(configObject);
 	};
 });
 

--- a/src/state/v2.ts
+++ b/src/state/v2.ts
@@ -19,7 +19,7 @@ export const checkoutServerSignal = persisted(
 );
 export const checkoutServerUrlSignal = createUrlSignal(checkoutServerSignal);
 
-export const sdkV2Signal = signal<SdkV2 | undefined>(undefined);
+export const sdkV2Signal = signal<Promise<SdkV2> | undefined>(undefined);
 
 effect(() => {
 	const version = sdkVersionSignal.value;
@@ -31,10 +31,7 @@ effect(() => {
 	let cleaned = false;
 	(async () => {
 		if (getMajorVersion(version) === "v2") {
-			const sdk = await loadSdkV2(
-				version as SdkV2Version,
-				checkoutServerUrl.origin,
-			);
+			const sdk = loadSdkV2(version as SdkV2Version, checkoutServerUrl.origin);
 			if (cleaned) return;
 			sdkV2Signal.value = sdk;
 		} else {
@@ -43,7 +40,7 @@ effect(() => {
 	})();
 	return () => {
 		cleaned = true;
-		sdkV2Signal.value?.cleanUp();
+		sdkV2Signal.value?.then((sdk) => sdk.cleanUp());
 	};
 });
 


### PR DESCRIPTION
기존 방식에서는 SDK가 로딩되어야 Signal에 SDK 객체가 저장되었는데, 이로 인해 버전 변경 후 바로 예제 실행을 누르면 SDK가 로드되지 않아 오류가 발생했습니다.

이를 방지하기 위해 SDK 객체를 Promise 형태로 Signal에 바로 저장해서 pending 상태일 경우 로딩이 완료될 때 까지 대기할 수 있도록 개선했습니다.