### PR TITLE
탭 레이아웃 구현 & 중복된 레이아웃 코드 통합

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@types/react": "^18.3.3",
 		"@uiw/react-codemirror": "^4.23.0",
 		"autoprefixer": "10.4.19",
+		"clsx": "^2.1.1",
 		"error-stack-parser-es": "^0.1.5",
 		"jquery": "^3.7.1",
 		"postcss": "8.4.39",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       autoprefixer:
         specifier: 10.4.19
         version: 10.4.19(postcss@8.4.39)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       error-stack-parser-es:
         specifier: ^0.1.5
         version: 0.1.5
@@ -768,6 +771,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   codemirror@6.0.1:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
@@ -2059,6 +2066,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  clsx@2.1.1: {}
 
   codemirror@6.0.1(@lezer/common@1.2.1):
     dependencies:

--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -1,33 +1,12 @@
-import {
-	type ReadonlySignal,
-	useSignal,
-	useSignalEffect,
-} from "@preact/signals";
+import { type Signal, useSignal } from "@preact/signals";
+import { useEffect } from "react";
 
-interface Size {
-	width: number | undefined;
-	height: number | undefined;
-}
-
-export function useWindowSize(): ReadonlySignal<Size> {
-	const windowSize = useSignal<Size>({
-		width: undefined,
-		height: undefined,
-	});
-
-	useSignalEffect(() => {
-		function handleResize() {
-			windowSize.value = {
-				width: window.innerWidth,
-				height: window.innerHeight,
-			};
-		}
-		window.addEventListener("resize", handleResize);
-		handleResize();
-		return () => {
-			window.removeEventListener("resize", handleResize);
+export function useMediaQueryMatches(query: string): Signal<boolean> {
+	const matchesSignal = useSignal(window.matchMedia(query).matches);
+	useEffect(() => {
+		window.matchMedia(query).onchange = (e) => {
+			matchesSignal.value = e.matches;
 		};
 	});
-
-	return windowSize;
+	return matchesSignal;
 }

--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -1,0 +1,33 @@
+import {
+	type ReadonlySignal,
+	useSignal,
+	useSignalEffect,
+} from "@preact/signals";
+
+interface Size {
+	width: number | undefined;
+	height: number | undefined;
+}
+
+export function useWindowSize(): ReadonlySignal<Size> {
+	const windowSize = useSignal<Size>({
+		width: undefined,
+		height: undefined,
+	});
+
+	useSignalEffect(() => {
+		function handleResize() {
+			windowSize.value = {
+				width: window.innerWidth,
+				height: window.innerHeight,
+			};
+		}
+		window.addEventListener("resize", handleResize);
+		handleResize();
+		return () => {
+			window.removeEventListener("resize", handleResize);
+		};
+	});
+
+	return windowSize;
+}

--- a/src/state/app.tsx
+++ b/src/state/app.tsx
@@ -16,6 +16,12 @@ export const appModeSignal = persisted<AppMode>(
 	{ sdkVersion: "2.0.0", fn: "v2-pay" },
 );
 
+export const selectedTabSignal = persisted<string>(
+	localStorage,
+	`${prefix}.selectedTab`,
+	"example",
+);
+
 export function getMajorVersion(sdkVersion: SdkVersion): MajorVersion {
 	const major = sdkVersion.split(".").shift();
 	if (major === "1") return "v1";

--- a/src/state/app.tsx
+++ b/src/state/app.tsx
@@ -16,12 +16,6 @@ export const appModeSignal = persisted<AppMode>(
 	{ sdkVersion: "2.0.0", fn: "v2-pay" },
 );
 
-export const selectedTabSignal = persisted<string>(
-	localStorage,
-	`${prefix}.selectedTab`,
-	"example",
-);
-
 export function getMajorVersion(sdkVersion: SdkVersion): MajorVersion {
 	const major = sdkVersion.split(".").shift();
 	if (major === "1") return "v1";

--- a/src/state/view.ts
+++ b/src/state/view.ts
@@ -1,0 +1,13 @@
+import persisted, { prefix } from "./persisted";
+
+const Tab = {
+	parameter: "parameter",
+	example: "example",
+} as const;
+export type Tab = (typeof Tab)[keyof typeof Tab];
+
+export const selectedTabSignal = persisted<Tab>(
+	localStorage,
+	`${prefix}.selectedTab`,
+	"example",
+);

--- a/src/state/view.ts
+++ b/src/state/view.ts
@@ -5,9 +5,16 @@ const Tab = {
 	example: "example",
 } as const;
 export type Tab = (typeof Tab)[keyof typeof Tab];
+export type TabDirection = "left" | "right";
+type TabState = {
+	[key in TabDirection]: Tab;
+};
 
-export const selectedTabSignal = persisted<Tab>(
+export const selectedTabSignal = persisted<TabState>(
 	localStorage,
 	`${prefix}.selectedTab`,
-	"example",
+	{
+		left: Tab.parameter,
+		right: Tab.example,
+	},
 );

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -20,7 +20,7 @@ export default function Tabs<K extends string>({
 	onSelect,
 }: TabProps<K>) {
 	return (
-		<div>
+		<div className="grid grid-rows-[auto_1fr] auto-cols-fr">
 			<ul className="flex">
 				{tabs.map((tab) => {
 					if (tab.visible === false) {
@@ -60,8 +60,11 @@ export default function Tabs<K extends string>({
 				}
 
 				const isSelected = tab.key === selectedTab;
+				if (!isSelected) {
+					return;
+				}
 
-				return <div key={tab.key}>{isSelected && tab.children}</div>;
+				return <div key={tab.key}>{tab.children}</div>;
 			})}
 		</div>
 	);

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -1,0 +1,64 @@
+import clsx from "clsx";
+import type React from "react";
+
+interface Tab {
+	key: string;
+	title: React.ReactNode;
+	visible?: boolean;
+	children: React.ReactNode;
+}
+
+interface TabProps {
+	selectedTab: string;
+	onSelect: (key: string) => void;
+	tabs: Tab[];
+}
+
+export default function Tabs({ tabs, selectedTab, onSelect }: TabProps) {
+	return (
+		<div>
+			<ul className="flex">
+				{tabs.map((tab) => {
+					if (tab.visible === false) {
+						return;
+					}
+
+					const isSelected = tab.key === selectedTab;
+
+					function onClick() {
+						if (!isSelected) {
+							onSelect(tab.key);
+						}
+					}
+
+					return (
+						<li
+							key={tab.key}
+							className={clsx(
+								"border-r px-4 py-2 text-sm shrink text-ellipsis overflow-hidden whitespace-nowrap text-slate hover:bg-slate-100",
+								{
+									"bg-slate-100": isSelected,
+									"cursor-pointer": !isSelected,
+								},
+							)}
+							onClick={onClick}
+							onKeyDown={onClick}
+						>
+							{tab.title}
+						</li>
+					);
+				})}
+			</ul>
+
+			{tabs.map((tab) => {
+				if (tab.visible === false) {
+					return;
+				}
+
+				const isSelected = tab.key === selectedTab;
+
+				return <div key={tab.key}>{isSelected && tab.children}</div>;
+			})}
+		</div>
+	);
+}

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -1,20 +1,24 @@
 import clsx from "clsx";
 import type React from "react";
 
-interface Tab {
-	key: string;
+export interface TabItem<K extends string> {
+	key: K;
 	title: React.ReactNode;
 	visible?: boolean;
 	children: React.ReactNode;
 }
 
-interface TabProps {
+interface TabProps<K extends string> {
 	selectedTab: string;
-	onSelect: (key: string) => void;
-	tabs: Tab[];
+	onSelect: (key: K) => void;
+	tabs: TabItem<K>[];
 }
 
-export default function Tabs({ tabs, selectedTab, onSelect }: TabProps) {
+export default function Tabs<K extends string>({
+	tabs,
+	selectedTab,
+	onSelect,
+}: TabProps<K>) {
 	return (
 		<div>
 			<ul className="flex">

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -39,7 +39,7 @@ export default function Tabs<K extends string>({
 						<li
 							key={tab.key}
 							className={clsx(
-								"border-r px-4 py-2 text-sm shrink text-ellipsis overflow-hidden whitespace-nowrap text-slate hover:bg-slate-100",
+								"flex border-r px-4 py-2 text-sm shrink text-ellipsis overflow-hidden whitespace-nowrap text-slate hover:bg-slate-100",
 								{
 									"bg-slate-100 font-bold": isSelected,
 									"cursor-pointer": !isSelected,

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -41,7 +41,7 @@ export default function Tabs<K extends string>({
 							className={clsx(
 								"border-r px-4 py-2 text-sm shrink text-ellipsis overflow-hidden whitespace-nowrap text-slate hover:bg-slate-100",
 								{
-									"bg-slate-100": isSelected,
+									"bg-slate-100 font-bold": isSelected,
 									"cursor-pointer": !isSelected,
 								},
 							)}

--- a/src/ui/mode/View.tsx
+++ b/src/ui/mode/View.tsx
@@ -84,9 +84,12 @@ export const View = ({
 				{hasNarrowWindow.value === false && parameterEditTab}
 				<Tabs
 					onSelect={(key) => {
-						selectedTabSignal.value = key;
+						selectedTabSignal.value = {
+							...selectedTabSignal.value,
+							right: key,
+						};
 					}}
-					selectedTab={selectedTabSignal.value}
+					selectedTab={selectedTabSignal.value.right}
 					tabs={
 						[
 							{

--- a/src/ui/mode/View.tsx
+++ b/src/ui/mode/View.tsx
@@ -1,0 +1,138 @@
+import {
+	type ReadonlySignal,
+	type Signal,
+	signal,
+	useComputed,
+	useSignal,
+} from "@preact/signals";
+import type * as React from "react";
+import { useWindowSize } from "../../misc/utils";
+import type { FieldSignals, Fields } from "../../state/fields";
+import { RequiredIndicator } from "../../ui/Control";
+import HtmlEditor from "../../ui/HtmlEditor";
+import JsonEditor from "../../ui/JsonEditor";
+import Tabs from "../Tabs";
+import FieldControls from "../field/FieldControls";
+import Reset from "./Reset";
+
+interface ViewProps {
+	forQa: React.ReactNode;
+	jsonValueSignal: ReadonlySignal<Record<string, unknown>>;
+	isEmptyJsonSignal: ReadonlySignal<boolean>;
+	jsonTextSignal: Signal<string>;
+	codePreviewSignal: ReadonlySignal<string>;
+	fields: Fields;
+	fieldSignals: FieldSignals;
+	prependControls?: React.ReactNode;
+	hidePaymentNotice?: boolean;
+	onReset: () => void;
+}
+
+export const View = ({
+	forQa,
+	jsonValueSignal,
+	isEmptyJsonSignal,
+	jsonTextSignal,
+	codePreviewSignal,
+	fields,
+	fieldSignals,
+	hidePaymentNotice,
+	prependControls,
+	onReset,
+}: ViewProps) => {
+	const parseJsonFailed = jsonValueSignal.value == null;
+	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+	const selectedTab = useSignal("parameter");
+	const windowSize = useWindowSize();
+	const hasNarrowWindow = useComputed(
+		() => windowSize.value.width !== undefined && windowSize.value.width < 768,
+	);
+	const resetCountSignal = signal(0);
+	const resetFn = () => {
+		onReset();
+		++resetCountSignal.value;
+	};
+
+	const parameterEdtior = (
+		<div className="flex flex-col gap-2 md:pb-80">
+			<Reset resetFn={resetFn} />
+			<details open={isJsonOpen.value}>
+				<summary
+					className={`text-xs ${
+						parseJsonFailed ? "text-red-700" : "text-slate-500"
+					} cursor-pointer`}
+				>
+					추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
+				</summary>
+				<JsonEditor
+					key={resetCountSignal.value}
+					value={jsonTextSignal.value}
+					onChange={(json) => {
+						jsonTextSignal.value = json;
+					}}
+					onReset={() => {
+						isJsonOpen.value = true;
+					}}
+				/>
+				<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
+					<summary className="text-xs text-slate-500 cursor-pointer">
+						포트원 내부 QA 전용 설정
+					</summary>
+					{forQa}
+				</details>
+			</details>
+			{prependControls}
+			<FieldControls fields={fields} fieldSignals={fieldSignals} />
+		</div>
+	);
+	return (
+		<>
+			<p className="mb-4 text-xs text-slate-500">
+				{hidePaymentNotice !== true && (
+					<div>
+						PG가 콘솔에서 테스트로 설정된 경우, 승인된 결제 건은 매일
+						자정(23:00~23:50분 사이)에 자동으로 취소됩니다.
+						<br />
+					</div>
+				)}
+				"<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
+				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
+			</p>
+			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+				{hasNarrowWindow.value === false && parameterEdtior}
+				<Tabs
+					onSelect={(key) => {
+						selectedTab.value = key;
+					}}
+					selectedTab={selectedTab.value}
+					tabs={[
+						{
+							title: "파라미터 입력",
+							key: "parameter",
+							children: parameterEdtior,
+							visible: hasNarrowWindow.value,
+						},
+						{
+							title: "연동 코드 예시",
+							key: "example",
+							children: (
+								<div
+									className="md:sticky top-4 flex flex-col"
+									style={{ height: "calc(100vh - 2rem)" }}
+								>
+									<div className="flex-1">
+										<HtmlEditor
+											className="h-full"
+											editable={false}
+											value={codePreviewSignal.value}
+										/>
+									</div>
+								</div>
+							),
+						},
+					]}
+				/>
+			</div>
+		</>
+	);
+};

--- a/src/ui/mode/View.tsx
+++ b/src/ui/mode/View.tsx
@@ -7,6 +7,7 @@ import {
 } from "@preact/signals";
 import type * as React from "react";
 import { useWindowSize } from "../../misc/utils";
+import { selectedTabSignal } from "../../state/app";
 import type { FieldSignals, Fields } from "../../state/fields";
 import { RequiredIndicator } from "../../ui/Control";
 import HtmlEditor from "../../ui/HtmlEditor";
@@ -42,7 +43,6 @@ export const View = ({
 }: ViewProps) => {
 	const parseJsonFailed = jsonValueSignal.value == null;
 	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
-	const selectedTab = useSignal("parameter");
 	const windowSize = useWindowSize();
 	const hasNarrowWindow = useComputed(
 		() => windowSize.value.width !== undefined && windowSize.value.width < 768,
@@ -102,9 +102,9 @@ export const View = ({
 				{hasNarrowWindow.value === false && parameterEdtior}
 				<Tabs
 					onSelect={(key) => {
-						selectedTab.value = key;
+						selectedTabSignal.value = key;
 					}}
-					selectedTab={selectedTab.value}
+					selectedTab={selectedTabSignal.value}
 					tabs={[
 						{
 							title: "파라미터 입력",

--- a/src/ui/mode/View.tsx
+++ b/src/ui/mode/View.tsx
@@ -5,7 +5,8 @@ import {
 	useComputed,
 } from "@preact/signals";
 import type * as React from "react";
-import { useWindowSize } from "../../misc/utils";
+import { useCallback } from "react";
+import { useMediaQueryMatches } from "../../misc/utils";
 import type { FieldSignals, Fields } from "../../state/fields";
 import { type Tab, selectedTabSignal } from "../../state/view";
 import { RequiredIndicator } from "../../ui/Control";
@@ -38,18 +39,15 @@ export const View = ({
 	prependControls,
 	onReset,
 }: ViewProps) => {
-	const windowSize = useWindowSize();
-	const hasNarrowWindow = useComputed(
-		() => windowSize.value.width !== undefined && windowSize.value.width < 768,
-	);
+	const hasNarrowWindow = useMediaQueryMatches("(max-width: 768px)");
 	const parseJsonFailedSignal = useComputed(
 		() => jsonValueSignal.value == null,
 	);
 	const resetCountSignal = signal(0);
-	const resetFn = () => {
+	const resetFn = useCallback(() => {
 		onReset();
 		++resetCountSignal.value;
-	};
+	}, [onReset, resetCountSignal]);
 
 	const parameterEditTab = (
 		<ParameterEditTab

--- a/src/ui/mode/v1-cert.tsx
+++ b/src/ui/mode/v1-cert.tsx
@@ -1,5 +1,3 @@
-import { signal, useSignal } from "@preact/signals";
-import type * as React from "react";
 import { reset as resetV1 } from "../../state/v1";
 import {
 	accountSignals,
@@ -11,110 +9,25 @@ import {
 	jsonValueSignal,
 	reset,
 } from "../../state/v1-cert";
-import Control, { RequiredIndicator } from "../../ui/Control";
-import HtmlEditor from "../../ui/HtmlEditor";
-import JsonEditor from "../../ui/JsonEditor";
-import FieldControls from "../field/FieldControls";
-import Reset from "./Reset";
-import { ForQa } from "./v1";
+import { View } from "./View";
+import { ForQa, V1PrependControls } from "./v1";
 
-const resetCountSignal = signal(0);
-const resetFn = () => {
-	resetV1();
-	reset();
-	++resetCountSignal.value;
-};
-
-const { userCodeSignal, tierCodeSignal, tierCodeEnabledSignal } =
-	accountSignals;
-
-const View: React.FC = () => {
-	const parseJsonFailed = jsonValueSignal.value == null;
-	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+export default function () {
 	return (
-		<>
-			<p className="mb-4 text-xs text-slate-500">
-				"<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
-				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
-			</p>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<div className="flex flex-col gap-2 md:pb-80">
-					<Reset resetFn={resetFn} />
-					<details open={isJsonOpen.value}>
-						<summary
-							className={`text-xs ${
-								parseJsonFailed ? "text-red-700" : "text-slate-500"
-							} cursor-pointer`}
-						>
-							추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
-						</summary>
-						<JsonEditor
-							key={resetCountSignal.value}
-							value={jsonTextSignal.value}
-							onChange={(json) => {
-								jsonTextSignal.value = json;
-							}}
-							onReset={() => {
-								isJsonOpen.value = true;
-							}}
-						/>
-						<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
-							<summary className="text-xs text-slate-500 cursor-pointer">
-								포트원 내부 QA 전용 설정
-							</summary>
-							<ForQa />
-						</details>
-					</details>
-					<Control required label="고객사 식별코드" code="userCode">
-						<input
-							className="border"
-							type="text"
-							placeholder="imp00000000"
-							value={userCodeSignal.value}
-							onInput={(e) => {
-								userCodeSignal.value = e.currentTarget.value;
-							}}
-						/>
-					</Control>
-					<Control
-						label="하위상점(Tier) 코드"
-						code="tierCode"
-						enabled={tierCodeEnabledSignal.value}
-						onToggle={(value) => {
-							tierCodeEnabledSignal.value = value;
-						}}
-					>
-						<input
-							className="border"
-							type="text"
-							placeholder="000"
-							value={tierCodeSignal.value}
-							onInput={(e) => {
-								tierCodeEnabledSignal.value = true;
-								tierCodeSignal.value = e.currentTarget.value;
-							}}
-						/>
-					</Control>
-					<FieldControls fields={fields} fieldSignals={fieldSignals} />
-				</div>
-				<div>
-					<div
-						className="md:sticky top-4 flex flex-col"
-						style={{ height: "calc(100vh - 2rem)" }}
-					>
-						<h2 className="text-xs text-slate-500">연동 코드 예시</h2>
-						<div className="flex-1">
-							<HtmlEditor
-								className="h-full"
-								editable={false}
-								value={codePreviewSignal.value}
-							/>
-						</div>
-					</div>
-				</div>
-			</div>
-		</>
+		<View
+			forQa={<ForQa />}
+			fields={fields}
+			fieldSignals={fieldSignals}
+			jsonTextSignal={jsonTextSignal}
+			jsonValueSignal={jsonValueSignal}
+			codePreviewSignal={codePreviewSignal}
+			isEmptyJsonSignal={isEmptyJsonSignal}
+			prependControls={<V1PrependControls accountSignals={accountSignals} />}
+			onReset={() => {
+				reset();
+				resetV1();
+			}}
+			hidePaymentNotice
+		/>
 	);
-};
-
-export default View;
+}

--- a/src/ui/mode/v1-load-ui.tsx
+++ b/src/ui/mode/v1-load-ui.tsx
@@ -1,5 +1,3 @@
-import { signal, useSignal } from "@preact/signals";
-import type * as React from "react";
 import { reset as resetV1 } from "../../state/v1";
 import {
 	accountSignals,
@@ -10,126 +8,25 @@ import {
 	jsonTextSignal,
 	jsonValueSignal,
 	reset,
-	uiTypeSignal,
 } from "../../state/v1-load-ui";
-import Control, { RequiredIndicator } from "../../ui/Control";
-import HtmlEditor from "../../ui/HtmlEditor";
-import JsonEditor from "../../ui/JsonEditor";
-import FieldControls from "../field/FieldControls";
-import Reset from "./Reset";
-import { ForQa } from "./v1";
+import { View } from "./View";
+import { ForQa, V1PrependControls } from "./v1";
 
-const resetCountSignal = signal(0);
-const resetFn = () => {
-	resetV1();
-	reset();
-	++resetCountSignal.value;
-};
-
-const { userCodeSignal, tierCodeSignal, tierCodeEnabledSignal } =
-	accountSignals;
-
-const View: React.FC = () => {
-	const parseJsonFailed = jsonValueSignal.value == null;
-	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+export default function () {
 	return (
-		<>
-			<p className="mb-4 text-xs text-slate-500">
-				PG가 콘솔에서 테스트로 설정된 경우, 승인된 결제 건은 매일
-				자정(23:00~23:50분 사이)에 자동으로 취소됩니다.
-				<br />
-				"<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
-				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
-			</p>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<div className="flex flex-col gap-2 md:pb-80">
-					<Reset resetFn={resetFn} />
-					<details open={isJsonOpen.value}>
-						<summary
-							className={`text-xs ${
-								parseJsonFailed ? "text-red-700" : "text-slate-500"
-							} cursor-pointer`}
-						>
-							추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
-						</summary>
-						<JsonEditor
-							key={resetCountSignal.value}
-							value={jsonTextSignal.value}
-							onChange={(json) => {
-								jsonTextSignal.value = json;
-							}}
-							onReset={() => {
-								isJsonOpen.value = true;
-							}}
-						/>
-						<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
-							<summary className="text-xs text-slate-500 cursor-pointer">
-								포트원 내부 QA 전용 설정
-							</summary>
-							<ForQa />
-						</details>
-					</details>
-					<Control required label="고객사 식별코드" code="userCode">
-						<input
-							className="border"
-							type="text"
-							placeholder="imp00000000"
-							value={userCodeSignal.value}
-							onInput={(e) => {
-								userCodeSignal.value = e.currentTarget.value;
-							}}
-						/>
-					</Control>
-					<Control
-						label="하위상점(Tier) 코드"
-						code="tierCode"
-						enabled={tierCodeEnabledSignal.value}
-						onToggle={(value) => {
-							tierCodeEnabledSignal.value = value;
-						}}
-					>
-						<input
-							className="border"
-							type="text"
-							placeholder="000"
-							value={tierCodeSignal.value}
-							onInput={(e) => {
-								tierCodeEnabledSignal.value = true;
-								tierCodeSignal.value = e.currentTarget.value;
-							}}
-						/>
-					</Control>
-					<Control required label="PG UI 형식" code="uiType">
-						<input
-							className="border"
-							type="text"
-							placeholder="paypal-spb"
-							value={uiTypeSignal.value}
-							onInput={(e) => {
-								uiTypeSignal.value = e.currentTarget.value;
-							}}
-						/>
-					</Control>
-					<FieldControls fields={fields} fieldSignals={fieldSignals} />
-				</div>
-				<div>
-					<div
-						className="md:sticky top-4 flex flex-col"
-						style={{ height: "calc(100vh - 2rem)" }}
-					>
-						<h2 className="text-xs text-slate-500">연동 코드 예시</h2>
-						<div className="flex-1">
-							<HtmlEditor
-								className="h-full"
-								editable={false}
-								value={codePreviewSignal.value}
-							/>
-						</div>
-					</div>
-				</div>
-			</div>
-		</>
+		<View
+			forQa={<ForQa />}
+			fields={fields}
+			fieldSignals={fieldSignals}
+			jsonTextSignal={jsonTextSignal}
+			jsonValueSignal={jsonValueSignal}
+			codePreviewSignal={codePreviewSignal}
+			isEmptyJsonSignal={isEmptyJsonSignal}
+			prependControls={<V1PrependControls accountSignals={accountSignals} />}
+			onReset={() => {
+				reset();
+				resetV1();
+			}}
+		/>
 	);
-};
-
-export default View;
+}

--- a/src/ui/mode/v1-pay.tsx
+++ b/src/ui/mode/v1-pay.tsx
@@ -1,5 +1,3 @@
-import { signal, useSignal } from "@preact/signals";
-import type * as React from "react";
 import { reset as resetV1 } from "../../state/v1";
 import {
 	accountSignals,
@@ -11,113 +9,24 @@ import {
 	jsonValueSignal,
 	reset,
 } from "../../state/v1-pay";
-import Control, { RequiredIndicator } from "../../ui/Control";
-import HtmlEditor from "../../ui/HtmlEditor";
-import JsonEditor from "../../ui/JsonEditor";
-import FieldControls from "../field/FieldControls";
-import Reset from "./Reset";
-import { ForQa } from "./v1";
+import { View } from "./View";
+import { ForQa, V1PrependControls } from "./v1";
 
-const resetCountSignal = signal(0);
-const resetFn = () => {
-	resetV1();
-	reset();
-	++resetCountSignal.value;
-};
-
-const { userCodeSignal, tierCodeSignal, tierCodeEnabledSignal } =
-	accountSignals;
-
-const View: React.FC = () => {
-	const parseJsonFailed = jsonValueSignal.value == null;
-	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+export default function () {
 	return (
-		<>
-			<p className="mb-4 text-xs text-slate-500">
-				PG가 콘솔에서 테스트로 설정된 경우, 승인된 결제 건은 매일
-				자정(23:00~23:50분 사이)에 자동으로 취소됩니다.
-				<br />
-				"<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
-				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
-			</p>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<div className="flex flex-col gap-2 md:pb-80">
-					<Reset resetFn={resetFn} />
-					<details open={isJsonOpen.value}>
-						<summary
-							className={`text-xs ${
-								parseJsonFailed ? "text-red-700" : "text-slate-500"
-							} cursor-pointer`}
-						>
-							추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
-						</summary>
-						<JsonEditor
-							key={resetCountSignal.value}
-							value={jsonTextSignal.value}
-							onChange={(json) => {
-								jsonTextSignal.value = json;
-							}}
-							onReset={() => {
-								isJsonOpen.value = true;
-							}}
-						/>
-						<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
-							<summary className="text-xs text-slate-500 cursor-pointer">
-								포트원 내부 QA 전용 설정
-							</summary>
-							<ForQa />
-						</details>
-					</details>
-					<Control required label="고객사 식별코드" code="userCode">
-						<input
-							className="border"
-							type="text"
-							placeholder="imp00000000"
-							value={userCodeSignal.value}
-							onInput={(e) => {
-								userCodeSignal.value = e.currentTarget.value;
-							}}
-						/>
-					</Control>
-					<Control
-						label="하위상점(Tier) 코드"
-						code="tierCode"
-						enabled={tierCodeEnabledSignal.value}
-						onToggle={(value) => {
-							tierCodeEnabledSignal.value = value;
-						}}
-					>
-						<input
-							className="border"
-							type="text"
-							placeholder="000"
-							value={tierCodeSignal.value}
-							onInput={(e) => {
-								tierCodeEnabledSignal.value = true;
-								tierCodeSignal.value = e.currentTarget.value;
-							}}
-						/>
-					</Control>
-					<FieldControls fields={fields} fieldSignals={fieldSignals} />
-				</div>
-				<div>
-					<div
-						className="md:sticky top-4 flex flex-col"
-						style={{ height: "calc(100vh - 2rem)" }}
-					>
-						<h2 className="text-xs text-slate-500">연동 코드 예시</h2>
-						<div className="flex-1">
-							<HtmlEditor
-								className="h-full"
-								editable={false}
-								value={codePreviewSignal.value}
-							/>
-						</div>
-					</div>
-				</div>
-			</div>
-		</>
+		<View
+			forQa={<ForQa />}
+			fields={fields}
+			fieldSignals={fieldSignals}
+			jsonTextSignal={jsonTextSignal}
+			jsonValueSignal={jsonValueSignal}
+			codePreviewSignal={codePreviewSignal}
+			isEmptyJsonSignal={isEmptyJsonSignal}
+			prependControls={<V1PrependControls accountSignals={accountSignals} />}
+			onReset={() => {
+				reset();
+				resetV1();
+			}}
+		/>
 	);
-};
-
-export default View;
+}

--- a/src/ui/mode/v1.tsx
+++ b/src/ui/mode/v1.tsx
@@ -1,5 +1,10 @@
 import { sdkVersionSignal } from "../../state/app";
-import { checkoutServerSignal, coreServerSignal } from "../../state/v1";
+import {
+	type AccountSignals,
+	checkoutServerSignal,
+	coreServerSignal,
+} from "../../state/v1";
+import Control from "../Control";
 
 export const ForQa = () => {
 	const version = sdkVersionSignal.value;
@@ -34,5 +39,50 @@ export const ForQa = () => {
 				</label>
 			)}
 		</div>
+	);
+};
+
+interface V1PrependControlsProps {
+	accountSignals: AccountSignals;
+}
+
+export const V1PrependControls = ({
+	accountSignals,
+}: V1PrependControlsProps) => {
+	const { userCodeSignal, tierCodeSignal, tierCodeEnabledSignal } =
+		accountSignals;
+	return (
+		<>
+			<Control required label="고객사 식별코드" code="userCode">
+				<input
+					className="border"
+					type="text"
+					placeholder="imp00000000"
+					value={userCodeSignal.value}
+					onInput={(e) => {
+						userCodeSignal.value = e.currentTarget.value;
+					}}
+				/>
+			</Control>
+			<Control
+				label="하위상점(Tier) 코드"
+				code="tierCode"
+				enabled={tierCodeEnabledSignal.value}
+				onToggle={(value) => {
+					tierCodeEnabledSignal.value = value;
+				}}
+			>
+				<input
+					className="border"
+					type="text"
+					placeholder="000"
+					value={tierCodeSignal.value}
+					onInput={(e) => {
+						tierCodeEnabledSignal.value = true;
+						tierCodeSignal.value = e.currentTarget.value;
+					}}
+				/>
+			</Control>
+		</>
 	);
 };

--- a/src/ui/mode/v2-identity-verification.tsx
+++ b/src/ui/mode/v2-identity-verification.tsx
@@ -1,6 +1,4 @@
-import { signal, useSignal } from "@preact/signals";
-import type * as React from "react";
-import { checkoutServerSignal, reset as resetV2 } from "../../state/v2";
+import { reset as resetV2 } from "../../state/v2";
 import {
 	codePreviewSignal,
 	fieldSignals,
@@ -10,88 +8,24 @@ import {
 	jsonValueSignal,
 	reset,
 } from "../../state/v2-identity-verification";
-import { RequiredIndicator } from "../Control";
-import HtmlEditor from "../HtmlEditor";
-import JsonEditor from "../JsonEditor";
-import FieldControls from "../field/FieldControls";
-import Reset from "./Reset";
+import { View } from "./View";
+import { ForQa } from "./v2";
 
-const resetCountSignal = signal(0);
-const resetFn = () => {
-	resetV2();
-	reset();
-	++resetCountSignal.value;
-};
-
-const View: React.FC = () => {
-	const parseJsonFailed = jsonValueSignal.value == null;
-	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+export default function () {
 	return (
-		<>
-			<p className="mb-4 text-xs text-slate-500">
-				"<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
-				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
-			</p>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<div className="flex flex-col gap-2 md:pb-80">
-					<Reset resetFn={resetFn} />
-					<details open={isJsonOpen.value}>
-						<summary
-							className={`text-xs ${
-								parseJsonFailed ? "text-red-700" : "text-slate-500"
-							} cursor-pointer`}
-						>
-							추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
-						</summary>
-						<JsonEditor
-							key={resetCountSignal.value}
-							value={jsonTextSignal.value}
-							onChange={(json) => {
-								jsonTextSignal.value = json;
-							}}
-							onReset={() => {
-								isJsonOpen.value = true;
-							}}
-						/>
-						<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
-							<summary className="text-xs text-slate-500 cursor-pointer">
-								포트원 내부 QA 전용 설정
-							</summary>
-							<div className="flex flex-col gap-2">
-								<label>
-									<div>Checkout API URL</div>
-									<input
-										type="text"
-										className="border w-full"
-										value={checkoutServerSignal.value}
-										onChange={(e) => {
-											checkoutServerSignal.value = e.currentTarget.value;
-										}}
-									/>
-								</label>
-							</div>
-						</details>
-					</details>
-					<FieldControls fields={fields} fieldSignals={fieldSignals} />
-				</div>
-				<div>
-					<div
-						className="md:sticky top-4 flex flex-col"
-						style={{ height: "calc(100vh - 2rem)" }}
-					>
-						<h2 className="text-xs text-slate-500">연동 코드 예시</h2>
-						<div className="flex-1">
-							<HtmlEditor
-								className="h-full"
-								editable={false}
-								value={codePreviewSignal.value}
-							/>
-						</div>
-					</div>
-				</div>
-			</div>
-		</>
+		<View
+			forQa={<ForQa />}
+			fields={fields}
+			fieldSignals={fieldSignals}
+			jsonTextSignal={jsonTextSignal}
+			jsonValueSignal={jsonValueSignal}
+			codePreviewSignal={codePreviewSignal}
+			isEmptyJsonSignal={isEmptyJsonSignal}
+			onReset={() => {
+				reset();
+				resetV2();
+			}}
+			hidePaymentNotice
+		/>
 	);
-};
-
-export default View;
+}

--- a/src/ui/mode/v2-issue-billing-key-and-pay.tsx
+++ b/src/ui/mode/v2-issue-billing-key-and-pay.tsx
@@ -1,6 +1,4 @@
-import { signal, useSignal } from "@preact/signals";
-import type * as React from "react";
-import { checkoutServerSignal, reset as resetV2 } from "../../state/v2";
+import { reset as resetV2 } from "../../state/v2";
 import {
 	codePreviewSignal,
 	fieldSignals,
@@ -10,91 +8,23 @@ import {
 	jsonValueSignal,
 	reset,
 } from "../../state/v2-issue-billing-key-and-pay";
-import { RequiredIndicator } from "../../ui/Control";
-import HtmlEditor from "../../ui/HtmlEditor";
-import JsonEditor from "../../ui/JsonEditor";
-import FieldControls from "../field/FieldControls";
-import Reset from "./Reset";
+import { View } from "./View";
+import { ForQa } from "./v2";
 
-const resetCountSignal = signal(0);
-const resetFn = () => {
-	resetV2();
-	reset();
-	++resetCountSignal.value;
-};
-
-const View: React.FC = () => {
-	const parseJsonFailed = jsonValueSignal.value == null;
-	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+export default function () {
 	return (
-		<>
-			<p className="mb-4 text-xs text-slate-500">
-				PG가 콘솔에서 테스트로 설정된 경우, 승인된 결제 건은 매일
-				자정(23:00~23:50분 사이)에 자동으로 취소됩니다.
-				<br />
-				"<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
-				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
-			</p>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<div className="flex flex-col gap-2 md:pb-80">
-					<Reset resetFn={resetFn} />
-					<details open={isJsonOpen.value}>
-						<summary
-							className={`text-xs ${
-								parseJsonFailed ? "text-red-700" : "text-slate-500"
-							} cursor-pointer`}
-						>
-							추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
-						</summary>
-						<JsonEditor
-							key={resetCountSignal.value}
-							value={jsonTextSignal.value}
-							onChange={(json) => {
-								jsonTextSignal.value = json;
-							}}
-							onReset={() => {
-								isJsonOpen.value = true;
-							}}
-						/>
-						<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
-							<summary className="text-xs text-slate-500 cursor-pointer">
-								포트원 내부 QA 전용 설정
-							</summary>
-							<div className="flex flex-col gap-2">
-								<label>
-									<div>Checkout API URL</div>
-									<input
-										type="text"
-										className="border w-full"
-										value={checkoutServerSignal.value}
-										onChange={(e) => {
-											checkoutServerSignal.value = e.currentTarget.value;
-										}}
-									/>
-								</label>
-							</div>
-						</details>
-					</details>
-					<FieldControls fields={fields} fieldSignals={fieldSignals} />
-				</div>
-				<div>
-					<div
-						className="md:sticky top-4 flex flex-col"
-						style={{ height: "calc(100vh - 2rem)" }}
-					>
-						<h2 className="text-xs text-slate-500">연동 코드 예시</h2>
-						<div className="flex-1">
-							<HtmlEditor
-								className="h-full"
-								editable={false}
-								value={codePreviewSignal.value}
-							/>
-						</div>
-					</div>
-				</div>
-			</div>
-		</>
+		<View
+			forQa={<ForQa />}
+			fields={fields}
+			fieldSignals={fieldSignals}
+			jsonTextSignal={jsonTextSignal}
+			jsonValueSignal={jsonValueSignal}
+			codePreviewSignal={codePreviewSignal}
+			isEmptyJsonSignal={isEmptyJsonSignal}
+			onReset={() => {
+				reset();
+				resetV2();
+			}}
+		/>
 	);
-};
-
-export default View;
+}

--- a/src/ui/mode/v2-issue-billing-key.tsx
+++ b/src/ui/mode/v2-issue-billing-key.tsx
@@ -1,6 +1,4 @@
-import { signal, useSignal } from "@preact/signals";
-import type * as React from "react";
-import { checkoutServerSignal, reset as resetV2 } from "../../state/v2";
+import { reset as resetV2 } from "../../state/v2";
 import {
 	codePreviewSignal,
 	fieldSignals,
@@ -10,88 +8,23 @@ import {
 	jsonValueSignal,
 	reset,
 } from "../../state/v2-issue-billing-key";
-import { RequiredIndicator } from "../../ui/Control";
-import HtmlEditor from "../../ui/HtmlEditor";
-import JsonEditor from "../../ui/JsonEditor";
-import FieldControls from "../field/FieldControls";
-import Reset from "./Reset";
+import { View } from "./View";
+import { ForQa } from "./v2";
 
-const resetCountSignal = signal(0);
-const resetFn = () => {
-	resetV2();
-	reset();
-	++resetCountSignal.value;
-};
-
-const View: React.FC = () => {
-	const parseJsonFailed = jsonValueSignal.value == null;
-	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+export default function () {
 	return (
-		<>
-			<p className="mb-4 text-xs text-slate-500">
-				"<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
-				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
-			</p>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<div className="flex flex-col gap-2 md:pb-80">
-					<Reset resetFn={resetFn} />
-					<details open={isJsonOpen.value}>
-						<summary
-							className={`text-xs ${
-								parseJsonFailed ? "text-red-700" : "text-slate-500"
-							} cursor-pointer`}
-						>
-							추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
-						</summary>
-						<JsonEditor
-							key={resetCountSignal.value}
-							value={jsonTextSignal.value}
-							onChange={(json) => {
-								jsonTextSignal.value = json;
-							}}
-							onReset={() => {
-								isJsonOpen.value = true;
-							}}
-						/>
-						<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
-							<summary className="text-xs text-slate-500 cursor-pointer">
-								포트원 내부 QA 전용 설정
-							</summary>
-							<div className="flex flex-col gap-2">
-								<label>
-									<div>Checkout API URL</div>
-									<input
-										type="text"
-										className="border w-full"
-										value={checkoutServerSignal.value}
-										onChange={(e) => {
-											checkoutServerSignal.value = e.currentTarget.value;
-										}}
-									/>
-								</label>
-							</div>
-						</details>
-					</details>
-					<FieldControls fields={fields} fieldSignals={fieldSignals} />
-				</div>
-				<div>
-					<div
-						className="md:sticky top-4 flex flex-col"
-						style={{ height: "calc(100vh - 2rem)" }}
-					>
-						<h2 className="text-xs text-slate-500">연동 코드 예시</h2>
-						<div className="flex-1">
-							<HtmlEditor
-								className="h-full"
-								editable={false}
-								value={codePreviewSignal.value}
-							/>
-						</div>
-					</div>
-				</div>
-			</div>
-		</>
+		<View
+			forQa={<ForQa />}
+			fields={fields}
+			fieldSignals={fieldSignals}
+			jsonTextSignal={jsonTextSignal}
+			jsonValueSignal={jsonValueSignal}
+			codePreviewSignal={codePreviewSignal}
+			isEmptyJsonSignal={isEmptyJsonSignal}
+			onReset={() => {
+				reset();
+				resetV2();
+			}}
+		/>
 	);
-};
-
-export default View;
+}

--- a/src/ui/mode/v2-load-billing-key-ui.tsx
+++ b/src/ui/mode/v2-load-billing-key-ui.tsx
@@ -1,6 +1,4 @@
-import { signal, useSignal } from "@preact/signals";
-import type * as React from "react";
-import { checkoutServerSignal, reset as resetV2 } from "../../state/v2";
+import { reset as resetV2 } from "../../state/v2";
 import {
 	codePreviewSignal,
 	fieldSignals,
@@ -10,91 +8,23 @@ import {
 	jsonValueSignal,
 	reset,
 } from "../../state/v2-load-billing-key-ui";
-import { RequiredIndicator } from "../Control";
-import HtmlEditor from "../HtmlEditor";
-import JsonEditor from "../JsonEditor";
-import FieldControls from "../field/FieldControls";
-import Reset from "./Reset";
+import { View } from "./View";
+import { ForQa } from "./v2";
 
-const resetCountSignal = signal(0);
-const resetFn = () => {
-	resetV2();
-	reset();
-	++resetCountSignal.value;
-};
-
-const View: React.FC = () => {
-	const parseJsonFailed = jsonValueSignal.value == null;
-	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+export default function () {
 	return (
-		<>
-			<p className="mb-4 text-xs text-slate-500">
-				PG가 콘솔에서 테스트로 설정된 경우, 승인된 결제 건은 매일
-				자정(23:00~23:50분 사이)에 자동으로 취소됩니다.
-				<br />
-				"<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
-				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
-			</p>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<div className="flex flex-col gap-2 md:pb-80">
-					<Reset resetFn={resetFn} />
-					<details open={isJsonOpen.value}>
-						<summary
-							className={`text-xs ${
-								parseJsonFailed ? "text-red-700" : "text-slate-500"
-							} cursor-pointer`}
-						>
-							추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
-						</summary>
-						<JsonEditor
-							key={resetCountSignal.value}
-							value={jsonTextSignal.value}
-							onChange={(json) => {
-								jsonTextSignal.value = json;
-							}}
-							onReset={() => {
-								isJsonOpen.value = true;
-							}}
-						/>
-						<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
-							<summary className="text-xs text-slate-500 cursor-pointer">
-								포트원 내부 QA 전용 설정
-							</summary>
-							<div className="flex flex-col gap-2">
-								<label>
-									<div>Checkout API URL</div>
-									<input
-										type="text"
-										className="border w-full"
-										value={checkoutServerSignal.value}
-										onChange={(e) => {
-											checkoutServerSignal.value = e.currentTarget.value;
-										}}
-									/>
-								</label>
-							</div>
-						</details>
-					</details>
-					<FieldControls fields={fields} fieldSignals={fieldSignals} />
-				</div>
-				<div>
-					<div
-						className="md:sticky top-4 flex flex-col"
-						style={{ height: "calc(100vh - 2rem)" }}
-					>
-						<h2 className="text-xs text-slate-500">연동 코드 예시</h2>
-						<div className="flex-1">
-							<HtmlEditor
-								className="h-full"
-								editable={false}
-								value={codePreviewSignal.value}
-							/>
-						</div>
-					</div>
-				</div>
-			</div>
-		</>
+		<View
+			forQa={<ForQa />}
+			fields={fields}
+			fieldSignals={fieldSignals}
+			jsonTextSignal={jsonTextSignal}
+			jsonValueSignal={jsonValueSignal}
+			codePreviewSignal={codePreviewSignal}
+			isEmptyJsonSignal={isEmptyJsonSignal}
+			onReset={() => {
+				reset();
+				resetV2();
+			}}
+		/>
 	);
-};
-
-export default View;
+}

--- a/src/ui/mode/v2-load-payment-ui.tsx
+++ b/src/ui/mode/v2-load-payment-ui.tsx
@@ -1,6 +1,4 @@
-import { signal, useSignal } from "@preact/signals";
-import type * as React from "react";
-import { checkoutServerSignal, reset as resetV2 } from "../../state/v2";
+import { reset as resetV2 } from "../../state/v2";
 import {
 	codePreviewSignal,
 	fieldSignals,
@@ -10,89 +8,23 @@ import {
 	jsonValueSignal,
 	reset,
 } from "../../state/v2-load-payment-ui";
-import { RequiredIndicator } from "../Control";
-import HtmlEditor from "../HtmlEditor";
-import JsonEditor from "../JsonEditor";
-import FieldControls from "../field/FieldControls";
-import Reset from "./Reset";
+import { View } from "./View";
+import { ForQa } from "./v2";
 
-const resetCountSignal = signal(0);
-const resetFn = () => {
-	resetV2();
-	reset();
-	++resetCountSignal.value;
-};
-
-const View: React.FC = () => {
-	const parseJsonFailed = jsonValueSignal.value == null;
-	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+export default function () {
 	return (
-		<>
-			<p className="mb-4 text-xs text-slate-500">
-				PG가 콘솔에서 테스트로 설정된 경우, 승인된 결제 건은 매일 "
-				<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
-				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
-			</p>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<div className="flex flex-col gap-2 md:pb-80">
-					<Reset resetFn={resetFn} />
-					<details open={isJsonOpen.value}>
-						<summary
-							className={`text-xs ${
-								parseJsonFailed ? "text-red-700" : "text-slate-500"
-							} cursor-pointer`}
-						>
-							추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
-						</summary>
-						<JsonEditor
-							key={resetCountSignal.value}
-							value={jsonTextSignal.value}
-							onChange={(json) => {
-								jsonTextSignal.value = json;
-							}}
-							onReset={() => {
-								isJsonOpen.value = true;
-							}}
-						/>
-						<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
-							<summary className="text-xs text-slate-500 cursor-pointer">
-								포트원 내부 QA 전용 설정
-							</summary>
-							<div className="flex flex-col gap-2">
-								<label>
-									<div>Checkout API URL</div>
-									<input
-										type="text"
-										className="border w-full"
-										value={checkoutServerSignal.value}
-										onChange={(e) => {
-											checkoutServerSignal.value = e.currentTarget.value;
-										}}
-									/>
-								</label>
-							</div>
-						</details>
-					</details>
-					<FieldControls fields={fields} fieldSignals={fieldSignals} />
-				</div>
-				<div>
-					<div
-						className="md:sticky top-4 flex flex-col"
-						style={{ height: "calc(100vh - 2rem)" }}
-					>
-						<h2 className="text-xs text-slate-500">연동 코드 예시</h2>
-						<div className="flex-1">
-							<HtmlEditor
-								className="h-full"
-								editable={false}
-								value={codePreviewSignal.value}
-							/>
-						</div>
-					</div>
-				</div>
-			</div>
-		</>
+		<View
+			forQa={<ForQa />}
+			fields={fields}
+			fieldSignals={fieldSignals}
+			jsonTextSignal={jsonTextSignal}
+			jsonValueSignal={jsonValueSignal}
+			codePreviewSignal={codePreviewSignal}
+			isEmptyJsonSignal={isEmptyJsonSignal}
+			onReset={() => {
+				reset();
+				resetV2();
+			}}
+		/>
 	);
-};
-
-export default View;
+}

--- a/src/ui/mode/v2-pay.tsx
+++ b/src/ui/mode/v2-pay.tsx
@@ -1,6 +1,4 @@
-import { signal, useSignal } from "@preact/signals";
-import type * as React from "react";
-import { checkoutServerSignal, reset as resetV2 } from "../../state/v2";
+import { reset as resetV2 } from "../../state/v2";
 import {
 	codePreviewSignal,
 	fieldSignals,
@@ -10,91 +8,23 @@ import {
 	jsonValueSignal,
 	reset,
 } from "../../state/v2-pay";
-import { RequiredIndicator } from "../../ui/Control";
-import HtmlEditor from "../../ui/HtmlEditor";
-import JsonEditor from "../../ui/JsonEditor";
-import FieldControls from "../field/FieldControls";
-import Reset from "./Reset";
+import { View } from "./View";
+import { ForQa } from "./v2";
 
-const resetCountSignal = signal(0);
-const resetFn = () => {
-	resetV2();
-	reset();
-	++resetCountSignal.value;
-};
-
-const View: React.FC = () => {
-	const parseJsonFailed = jsonValueSignal.value == null;
-	const isJsonOpen = useSignal(isEmptyJsonSignal.value);
+export default function () {
 	return (
-		<>
-			<p className="mb-4 text-xs text-slate-500">
-				PG가 콘솔에서 테스트로 설정된 경우, 승인된 결제 건은 매일
-				자정(23:00~23:50분 사이)에 자동으로 취소됩니다.
-				<br />
-				"<RequiredIndicator />" 표시는 필수입력 항목을 의미합니다. 상황에 따라서
-				필수입력 표시가 아니어도 입력이 필요할 수 있습니다.
-			</p>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<div className="flex flex-col gap-2 md:pb-80">
-					<Reset resetFn={resetFn} />
-					<details open={isJsonOpen.value}>
-						<summary
-							className={`text-xs ${
-								parseJsonFailed ? "text-red-700" : "text-slate-500"
-							} cursor-pointer`}
-						>
-							추가 파라미터 (JSON{parseJsonFailed && " 파싱 실패"})
-						</summary>
-						<JsonEditor
-							key={resetCountSignal.value}
-							value={jsonTextSignal.value}
-							onChange={(json) => {
-								jsonTextSignal.value = json;
-							}}
-							onReset={() => {
-								isJsonOpen.value = true;
-							}}
-						/>
-						<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
-							<summary className="text-xs text-slate-500 cursor-pointer">
-								포트원 내부 QA 전용 설정
-							</summary>
-							<div className="flex flex-col gap-2">
-								<label>
-									<div>Checkout API URL</div>
-									<input
-										type="text"
-										className="border w-full"
-										value={checkoutServerSignal.value}
-										onChange={(e) => {
-											checkoutServerSignal.value = e.currentTarget.value;
-										}}
-									/>
-								</label>
-							</div>
-						</details>
-					</details>
-					<FieldControls fields={fields} fieldSignals={fieldSignals} />
-				</div>
-				<div>
-					<div
-						className="md:sticky top-4 flex flex-col"
-						style={{ height: "calc(100vh - 2rem)" }}
-					>
-						<h2 className="text-xs text-slate-500">연동 코드 예시</h2>
-						<div className="flex-1">
-							<HtmlEditor
-								className="h-full"
-								editable={false}
-								value={codePreviewSignal.value}
-							/>
-						</div>
-					</div>
-				</div>
-			</div>
-		</>
+		<View
+			forQa={<ForQa />}
+			fields={fields}
+			fieldSignals={fieldSignals}
+			jsonTextSignal={jsonTextSignal}
+			jsonValueSignal={jsonValueSignal}
+			codePreviewSignal={codePreviewSignal}
+			isEmptyJsonSignal={isEmptyJsonSignal}
+			onReset={() => {
+				reset();
+				resetV2();
+			}}
+		/>
 	);
-};
-
-export default View;
+}

--- a/src/ui/mode/v2.tsx
+++ b/src/ui/mode/v2.tsx
@@ -1,0 +1,17 @@
+import { checkoutServerSignal } from "../../state/v2";
+
+export const ForQa = () => (
+	<div className="flex flex-col gap-2">
+		<label>
+			<div>Checkout API URL</div>
+			<input
+				type="text"
+				className="border w-full"
+				value={checkoutServerSignal.value}
+				onChange={(e) => {
+					checkoutServerSignal.value = e.currentTarget.value;
+				}}
+			/>
+		</label>
+	</div>
+);

--- a/src/ui/tabs/CodeExampleTab.tsx
+++ b/src/ui/tabs/CodeExampleTab.tsx
@@ -1,0 +1,23 @@
+import type { ReadonlySignal } from "@preact/signals";
+import HtmlEditor from "../HtmlEditor";
+
+interface CodeExampleTabProps {
+	codePreviewSignal: ReadonlySignal<string>;
+}
+
+export const CodeExampleTab = ({ codePreviewSignal }: CodeExampleTabProps) => {
+	return (
+		<div
+			className="md:sticky top-4 flex flex-col"
+			style={{ height: "calc(100vh - 2rem)" }}
+		>
+			<div className="flex-1">
+				<HtmlEditor
+					className="h-full"
+					editable={false}
+					value={codePreviewSignal.value}
+				/>
+			</div>
+		</div>
+	);
+};

--- a/src/ui/tabs/ParameterEditTab.tsx
+++ b/src/ui/tabs/ParameterEditTab.tsx
@@ -1,0 +1,64 @@
+import { type ReadonlySignal, type Signal, useSignal } from "@preact/signals";
+import { useState } from "react";
+import type { FieldSignals, Fields } from "../../state/fields";
+import JsonEditor from "../JsonEditor";
+import FieldControls from "../field/FieldControls";
+import Reset from "../mode/Reset";
+
+interface ParameterEditTabProps {
+	resetFn: () => void;
+	parseJsonFailedSignal: ReadonlySignal<boolean>;
+	isEmptyJsonSignal: ReadonlySignal<boolean>;
+	resetCountSignal: ReadonlySignal<number>;
+	jsonTextSignal: Signal<string>;
+	forQa: React.ReactNode;
+	prependControls?: React.ReactNode;
+	fields: Fields;
+	fieldSignals: FieldSignals;
+}
+
+export const ParameterEditTab = ({
+	resetFn,
+	parseJsonFailedSignal,
+	isEmptyJsonSignal,
+	resetCountSignal,
+	jsonTextSignal,
+	forQa,
+	prependControls,
+	fields,
+	fieldSignals,
+}: ParameterEditTabProps) => {
+	const [isJsonOpen, setIsJsonOpen] = useState(isEmptyJsonSignal.value);
+	return (
+		<div className="flex flex-col gap-2 md:pb-80">
+			<Reset resetFn={resetFn} />
+			<details open={isJsonOpen}>
+				<summary
+					className={`text-xs ${
+						parseJsonFailedSignal.value ? "text-red-700" : "text-slate-500"
+					} cursor-pointer`}
+				>
+					추가 파라미터 (JSON{parseJsonFailedSignal.value && " 파싱 실패"})
+				</summary>
+				<JsonEditor
+					key={resetCountSignal.value}
+					value={jsonTextSignal.value}
+					onChange={(json) => {
+						jsonTextSignal.value = json;
+					}}
+					onReset={() => {
+						setIsJsonOpen(true);
+					}}
+				/>
+				<details className="open:py-2 opacity-0 hover:opacity-100 open:opacity-100 transition-all delay-100">
+					<summary className="text-xs text-slate-500 cursor-pointer">
+						포트원 내부 QA 전용 설정
+					</summary>
+					{forQa}
+				</details>
+			</details>
+			{prependControls}
+			<FieldControls fields={fields} fieldSignals={fieldSignals} />
+		</div>
+	);
+};


### PR DESCRIPTION
#65 #66 

[Slack 논의](https://portone-io.slack.com/archives/C02KQFUB8GG/p1720693305410259?thread_ts=1720092855.025359&cid=C02KQFUB8GG)

- 각 기능을 탭으로 분리하는 작업을 진행했습니다.
- mode별 페이지를 View 컴포넌트로 통합했습니다.

개인적으로 (P)React 환경에서 리팩토링은 생소한 작업이어서 이 방향성이 맞는지도 한번 봐주시면 감사하겠습니다 🙏 
- useSignalEffect에서 window의 resize 이벤트로 width를 구하는 방법이 적절했는지
- mode별로 분리된 페이지를 하나로 합치는 작업이 적절했는지
- signal을 적절하게 사용했는지
- 그 외...

![image](https://github.com/user-attachments/assets/d363216d-c926-4aba-bd6c-b5f679226124)
![image](https://github.com/user-attachments/assets/fc9d89ec-b0e6-4b4c-ab3d-93db0224a9d5)
