### PR TITLE
CodeMirror에서 readOnly 대신 editable을 사용하도록 수정

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -125,7 +125,7 @@ const Header: React.FC = () => {
 										className="text-black"
 										value={JSON.stringify(playResult.response, null, 2)}
 										extensions={[EditorView.lineWrapping]}
-										readOnly
+										editable={false}
 									/>
 								)}
 								{playResult.errorStack != null && (

--- a/src/ui/mode/v1-cert.tsx
+++ b/src/ui/mode/v1-cert.tsx
@@ -106,7 +106,7 @@ const View: React.FC = () => {
 						<div className="flex-1">
 							<HtmlEditor
 								className="h-full"
-								readOnly
+								editable={false}
 								value={codePreviewSignal.value}
 							/>
 						</div>

--- a/src/ui/mode/v1-load-ui.tsx
+++ b/src/ui/mode/v1-load-ui.tsx
@@ -121,7 +121,7 @@ const View: React.FC = () => {
 						<div className="flex-1">
 							<HtmlEditor
 								className="h-full"
-								readOnly
+								editable={false}
 								value={codePreviewSignal.value}
 							/>
 						</div>

--- a/src/ui/mode/v1-pay.tsx
+++ b/src/ui/mode/v1-pay.tsx
@@ -109,7 +109,7 @@ const View: React.FC = () => {
 						<div className="flex-1">
 							<HtmlEditor
 								className="h-full"
-								readOnly
+								editable={false}
 								value={codePreviewSignal.value}
 							/>
 						</div>

--- a/src/ui/mode/v2-identity-verification.tsx
+++ b/src/ui/mode/v2-identity-verification.tsx
@@ -83,7 +83,7 @@ const View: React.FC = () => {
 						<div className="flex-1">
 							<HtmlEditor
 								className="h-full"
-								readOnly
+								editable={false}
 								value={codePreviewSignal.value}
 							/>
 						</div>

--- a/src/ui/mode/v2-issue-billing-key-and-pay.tsx
+++ b/src/ui/mode/v2-issue-billing-key-and-pay.tsx
@@ -86,7 +86,7 @@ const View: React.FC = () => {
 						<div className="flex-1">
 							<HtmlEditor
 								className="h-full"
-								readOnly
+								editable={false}
 								value={codePreviewSignal.value}
 							/>
 						</div>

--- a/src/ui/mode/v2-issue-billing-key.tsx
+++ b/src/ui/mode/v2-issue-billing-key.tsx
@@ -83,7 +83,7 @@ const View: React.FC = () => {
 						<div className="flex-1">
 							<HtmlEditor
 								className="h-full"
-								readOnly
+								editable={false}
 								value={codePreviewSignal.value}
 							/>
 						</div>

--- a/src/ui/mode/v2-load-billing-key-ui.tsx
+++ b/src/ui/mode/v2-load-billing-key-ui.tsx
@@ -86,7 +86,7 @@ const View: React.FC = () => {
 						<div className="flex-1">
 							<HtmlEditor
 								className="h-full"
-								readOnly
+								editable={false}
 								value={codePreviewSignal.value}
 							/>
 						</div>

--- a/src/ui/mode/v2-load-payment-ui.tsx
+++ b/src/ui/mode/v2-load-payment-ui.tsx
@@ -84,7 +84,7 @@ const View: React.FC = () => {
 						<div className="flex-1">
 							<HtmlEditor
 								className="h-full"
-								readOnly
+								editable={false}
 								value={codePreviewSignal.value}
 							/>
 						</div>

--- a/src/ui/mode/v2-pay.tsx
+++ b/src/ui/mode/v2-pay.tsx
@@ -86,7 +86,7 @@ const View: React.FC = () => {
 						<div className="flex-1">
 							<HtmlEditor
 								className="h-full"
-								readOnly
+								editable={false}
 								value={codePreviewSignal.value}
 							/>
 						</div>


### PR DESCRIPTION
최신 @uiw/react-codemirror 의 CodeMirror 컴포넌트에서 readOnly 프로퍼티를 사용해도 코드 수정이 가능한 버그가 있어서 editable 프로퍼티로 대체합니다.