### PR TITLE
ci: GitHub Actions 보안 취약점 수정 (zizmor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           run_install: true
       - run: pnpm lint:ci


### PR DESCRIPTION
## 개요

[zizmor](https://github.com/woodruffw/zizmor)로 GitHub Actions 워크플로우 보안 감사를 수행하고 자동 수정 가능한 항목을 적용했습니다.

## 수정 내용

- **unpinned-uses**: 액션 참조를 버전 태그에서 전체 커밋 SHA로 고정
  - `actions/checkout@v4` → `@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
  - `actions/setup-node@v4` → `@49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0)
  - `pnpm/action-setup@v4` → `@b906affcce14559ad1aafd4ab0e942779e9f58b1` (v4.3.0)
- **artipacked**: `actions/checkout` 에 `persist-credentials: false` 추가하여 자격증명이 아티팩트에 노출되지 않도록 수정